### PR TITLE
Add minimal PyQt6 app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Fusor
+
+Fusor is a minimal PyQt6 application with a main window titled **"Fusor – Laravel/PHP QA Toolbox"**.
+
+## Running
+
+Install the dependencies and execute `main.py`:
+
+```bash
+pip install PyQt6
+python3 main.py
+```

--- a/main.py
+++ b/main.py
@@ -1,0 +1,19 @@
+import sys
+from PyQt6.QtWidgets import QApplication, QMainWindow
+
+
+class MainWindow(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Fusor – Laravel/PHP QA Toolbox")
+
+
+def main():
+    app = QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a simple PyQt6 main window titled "Fusor – Laravel/PHP QA Toolbox"
- document how to run the application in README

## Testing
- `python3 main.py` *(fails: Qt platform plugin "xcb" can't be initialized)*