### PR TITLE
Add configurable PHP path

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import sys
+import os
 import subprocess
 from PyQt6.QtWidgets import (
     QApplication,
@@ -52,6 +53,9 @@ class MainWindow(QMainWindow):
         # Redirect stdout to the output view
         self._stdout_logger = QTextEditLogger(self.output_view, sys.stdout)
         sys.stdout = self._stdout_logger
+
+        # Directory containing php and artisan executables
+        self.php_path = ""
 
         self.init_project_tab()
         self.init_git_tab()
@@ -182,6 +186,9 @@ class MainWindow(QMainWindow):
         self.var2_edit = QLineEdit()
         layout.addRow("Variable 2:", self.var2_edit)
 
+        self.php_path_edit = QLineEdit()
+        layout.addRow("PHP Path:", self.php_path_edit)
+
         self.framework_combo = QComboBox()
         self.framework_combo.addItems(["Laravel", "Yii", "None"])
         layout.addRow("Framework:", self.framework_combo)
@@ -201,38 +208,51 @@ class MainWindow(QMainWindow):
         git_url = self.git_url_edit.text()
         var1 = self.var1_edit.text()
         var2 = self.var2_edit.text()
+        php_path = self.php_path_edit.text()
         framework = self.framework_combo.currentText()
         
-        if not git_url or not var1 or not var2:
+        if not git_url or not var1 or not var2 or not php_path:
             QMessageBox.warning(self, "Invalid settings", "All settings fields must be filled out.")
             print("Failed to save settings: one or more fields were empty")
             return
 
+        if not os.path.isdir(php_path):
+            QMessageBox.warning(self, "Invalid PHP path", "The specified PHP path does not exist.")
+            print(f"Failed to save settings: directory does not exist - {php_path}")
+            return
+
+        self.php_path = php_path
+
         print(
-            f"Settings saved: Git URL={git_url}, Variable 1={var1}, Variable 2={var2}, Framework={framework}"
+            f"Settings saved: Git URL={git_url}, Variable 1={var1}, Variable 2={var2}, PHP Path={php_path}, Framework={framework}"
         )
+
+    def artisan(self, *args):
+        php_exe = os.path.join(self.php_path, "php") if self.php_path else "php"
+        artisan_file = os.path.join(self.php_path, "artisan") if self.php_path else "artisan"
+        self.run_command([php_exe, artisan_file, *args])
 
     def migrate(self):
         if self.current_framework() == "Laravel":
-            self.run_command(["php", "artisan", "migrate"])
+            self.artisan("migrate")
         else:
             print(f"Migrate not implemented for {self.current_framework()}")
 
     def rollback(self):
         if self.current_framework() == "Laravel":
-            self.run_command(["php", "artisan", "migrate:rollback"])
+            self.artisan("migrate:rollback")
         else:
             print(f"Rollback not implemented for {self.current_framework()}")
 
     def fresh(self):
         if self.current_framework() == "Laravel":
-            self.run_command(["php", "artisan", "migrate:fresh"])
+            self.artisan("migrate:fresh")
         else:
             print(f"Fresh not implemented for {self.current_framework()}")
 
     def seed(self):
         if self.current_framework() == "Laravel":
-            self.run_command(["php", "artisan", "db:seed"])
+            self.artisan("db:seed")
         else:
             print(f"Seed not implemented for {self.current_framework()}")
 


### PR DESCRIPTION
## Summary
- allow configuring the directory that contains `php` and `artisan`
- use the configured path for artisan commands
- validate the PHP path when saving settings

## Testing
- `pip install -r requirements.txt`
- `python3 -m py_compile main.py`