### PR TITLE
Add browse button for project path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ The available tabs are:
 - **Git** – simple controls for common Git actions.
 - **Database** – quick actions for opening and dumping a database.
 - **Logs** – displays example log text with a refresh option.
-- **Settings** – form fields for configuring the Git URL and other variables.
+- **Settings** – form fields for configuring the Git URL and other variables. A
+  *Browse* button lets you pick the project directory.
 
 ## Running
 

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -1,4 +1,13 @@
-from PyQt6.QtWidgets import QWidget, QFormLayout, QLineEdit, QComboBox, QPushButton, QSizePolicy
+from PyQt6.QtWidgets import (
+    QWidget,
+    QFormLayout,
+    QLineEdit,
+    QComboBox,
+    QPushButton,
+    QSizePolicy,
+    QHBoxLayout,
+    QFileDialog,
+)
 
 
 class SettingsTab(QWidget):
@@ -15,7 +24,14 @@ class SettingsTab(QWidget):
 
         self.project_path_edit = QLineEdit()
         self.project_path_edit.setText(self.main_window.project_path)
-        layout.addRow("Project Path:", self.project_path_edit)
+        path_container = QWidget()
+        path_layout = QHBoxLayout(path_container)
+        path_layout.setContentsMargins(0, 0, 0, 0)
+        path_layout.addWidget(self.project_path_edit)
+        browse_btn = QPushButton("Browse")
+        browse_btn.clicked.connect(self.browse_project_path)
+        path_layout.addWidget(browse_btn)
+        layout.addRow("Project Path:", path_container)
 
         self.framework_combo = QComboBox()
         self.framework_combo.addItems(["Laravel", "Yii", "None"])
@@ -30,3 +46,14 @@ class SettingsTab(QWidget):
         self.main_window.git_url_edit = self.git_url_edit
         self.main_window.project_path_edit = self.project_path_edit
         self.main_window.framework_combo = self.framework_combo
+
+    def browse_project_path(self):
+        """Open a folder selection dialog and update the path field."""
+        directory = QFileDialog.getExistingDirectory(
+            self,
+            "Select Project Directory",
+            self.project_path_edit.text() or self.main_window.project_path,
+        )
+        if directory:
+            self.project_path_edit.setText(directory)
+


### PR DESCRIPTION
## Summary
- add a browse button to Settings tab for selecting the project directory
- mention browse button in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`