### PR TITLE
Add global project path check

### DIFF
--- a/fusor/tabs/git_tab.py
+++ b/fusor/tabs/git_tab.py
@@ -44,8 +44,7 @@ class GitTab(QWidget):
         layout.addWidget(stash_btn)
 
     def run_git_command(self, *args):
-        if not self.main_window.project_path:
-            print("Project path not set")
+        if not self.main_window.ensure_project_path():
             return
         command = ["git", *args]
         print(f"$ {' '.join(command)}")
@@ -64,7 +63,7 @@ class GitTab(QWidget):
             print("Command not found: git")
 
     def load_branches(self):
-        if not self.main_window.project_path:
+        if not self.main_window.ensure_project_path():
             return
         try:
             result = subprocess.run(
@@ -93,8 +92,7 @@ class GitTab(QWidget):
             print("Command not found: git")
 
     def checkout(self, branch):
-        if not self.main_window.project_path:
-            print("Project path not set")
+        if not self.main_window.ensure_project_path():
             return
         self.run_git_command("checkout", branch)
         self.current_branch = branch
@@ -102,8 +100,7 @@ class GitTab(QWidget):
     def on_branch_changed(self, branch):
         if not branch or branch == self.current_branch:
             return
-        if not self.main_window.project_path:
-            print("Project path not set")
+        if not self.main_window.ensure_project_path():
             self.branch_combo.blockSignals(True)
             self.branch_combo.setCurrentText(self.current_branch)
             self.branch_combo.blockSignals(False)


### PR DESCRIPTION
## Summary
- show a folder dialog on startup to set the project path
- introduce `ensure_project_path` and use it from tabs
- remove local project path guards in GitTab

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687370917d0c83228c0886985f84e931