### PR TITLE
Handle missing project path

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -130,7 +130,7 @@ class MainWindow(QMainWindow):
         self.executor.submit(task)
 
     def ensure_project_path(self):
-        """Return True if project path is set else warn the user."""
+        """Warn and close the app if the project path is not set."""
         if not self.project_path:
             QMessageBox.warning(
                 self,
@@ -138,6 +138,7 @@ class MainWindow(QMainWindow):
                 "Please set the project path in Settings.",
             )
             print("Project path not set")
+            self.close()
             return False
         return True
 
@@ -148,6 +149,7 @@ class MainWindow(QMainWindow):
             self.project_path = path
             if hasattr(self, "project_path_edit"):
                 self.project_path_edit.setText(path)
+        self.ensure_project_path()
 
     def current_framework(self):
         return self.framework_combo.currentText() if hasattr(self, "framework_combo") else "None"
@@ -155,8 +157,7 @@ class MainWindow(QMainWindow):
     def refresh_logs(self):
         print("Refresh logs clicked")
 
-        if not self.ensure_project_path():
-            return
+        self.ensure_project_path()
 
         framework = self.current_framework()
         log_contents = ""
@@ -212,8 +213,7 @@ class MainWindow(QMainWindow):
         )
 
     def artisan(self, *args):
-        if not self.ensure_project_path():
-            return
+        self.ensure_project_path()
         artisan_file = os.path.join(self.project_path, "artisan")
         self.run_command(["php", artisan_file, *args])
 

--- a/fusor/tabs/git_tab.py
+++ b/fusor/tabs/git_tab.py
@@ -44,8 +44,7 @@ class GitTab(QWidget):
         layout.addWidget(stash_btn)
 
     def run_git_command(self, *args):
-        if not self.main_window.ensure_project_path():
-            return
+        self.main_window.ensure_project_path()
         command = ["git", *args]
         print(f"$ {' '.join(command)}")
         try:
@@ -63,8 +62,7 @@ class GitTab(QWidget):
             print("Command not found: git")
 
     def load_branches(self):
-        if not self.main_window.ensure_project_path():
-            return
+        self.main_window.ensure_project_path()
         try:
             result = subprocess.run(
                 ["git", "branch", "--format=%(refname:short)"],
@@ -92,19 +90,14 @@ class GitTab(QWidget):
             print("Command not found: git")
 
     def checkout(self, branch):
-        if not self.main_window.ensure_project_path():
-            return
+        self.main_window.ensure_project_path()
         self.run_git_command("checkout", branch)
         self.current_branch = branch
 
     def on_branch_changed(self, branch):
         if not branch or branch == self.current_branch:
             return
-        if not self.main_window.ensure_project_path():
-            self.branch_combo.blockSignals(True)
-            self.branch_combo.setCurrentText(self.current_branch)
-            self.branch_combo.blockSignals(False)
-            return
+        self.main_window.ensure_project_path()
         reply = QMessageBox.question(
             self,
             "Checkout Branch",


### PR DESCRIPTION
## Summary
- ensure_project_path now closes the app if no project path is set
- call ensure_project_path after asking for project path
- drop guard clauses and just ensure the path for Git actions and logs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6873773bfbe88322916aaa68bd10deac