### PR TITLE
Fix early git commands when project path missing

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -73,7 +73,9 @@ class MainWindow(QMainWindow):
         if self.framework_choice in [self.framework_combo.itemText(i) for i in range(self.framework_combo.count())]:
             self.framework_combo.setCurrentText(self.framework_choice)
 
-        if not self.project_path:
+        if self.project_path:
+            self.git_tab.load_branches()
+        else:
             QTimer.singleShot(0, self.ask_project_path)
 
     def load_config(self):
@@ -114,7 +116,10 @@ class MainWindow(QMainWindow):
             self.project_path = path
             if hasattr(self, "project_path_edit"):
                 self.project_path_edit.setText(path)
-        self.ensure_project_path()
+        if self.ensure_project_path():
+            # update git branch list now that the project path is set
+            if hasattr(self, "git_tab"):
+                self.git_tab.load_branches()
 
     def current_framework(self):
         return self.framework_combo.currentText() if hasattr(self, "framework_combo") else "None"
@@ -175,6 +180,8 @@ class MainWindow(QMainWindow):
         print(
             f"Settings saved: Git URL={git_url}, PHP Path={project_path}, Framework={framework}"
         )
+        if hasattr(self, "git_tab"):
+            self.git_tab.load_branches()
 
     def artisan(self, *args):
         self.ensure_project_path()

--- a/fusor/tabs/git_tab.py
+++ b/fusor/tabs/git_tab.py
@@ -24,7 +24,7 @@ class GitTab(QWidget):
         layout.addWidget(self.branch_combo)
 
         self.current_branch = ""
-        self.load_branches()
+        # branches are loaded once the project path is available
         self.branch_combo.currentTextChanged.connect(self.on_branch_changed)
 
         pull_btn = QPushButton("Pull")
@@ -61,7 +61,9 @@ class GitTab(QWidget):
             print("Command not found: git")
 
     def load_branches(self):
-        self.main_window.ensure_project_path()
+        """Populate the branch combo if a project path is available."""
+        if not self.main_window.project_path:
+            return
         try:
             result = subprocess.run(
                 ["git", "branch", "--format=%(refname:short)"],


### PR DESCRIPTION
## Summary
- avoid running git at startup if the project path is unset
- load git branches after a project path is chosen or saved

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`