### PR TITLE
Remove unused Git URL setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ The available tabs are:
 -   **Git** – simple controls for common Git actions.
 -   **Database** – quick actions for opening and dumping a database.
 -   **Logs** – shows your project's log file (Laravel only) with a refresh option.
--   **Settings** – form fields for configuring the Git URL and other variables. A
-    _Browse_ button lets you pick the project directory.
+-   **Settings** – fields for selecting the project directory and framework.
+    A _Browse_ button lets you pick the project directory.
 
-The application stores your selected project path, Git URL and framework in
+The application stores your selected project path and framework in
 `~/.fusor_config.json`. These values are restored automatically when the
 application starts.
 

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -47,7 +47,6 @@ class MainWindow(QMainWindow):
 
         # Directory containing php and artisan executables
         self.project_path = ""
-        self.git_url = ""
         self.framework_choice = "Laravel"
         self.load_config()
 
@@ -68,7 +67,6 @@ class MainWindow(QMainWindow):
         self.tabs.addTab(self.settings_tab, "Settings")
 
         # populate settings widgets with loaded values
-        self.git_url_edit.setText(self.git_url)
         self.project_path_edit.setText(self.project_path)
         if self.framework_choice in [self.framework_combo.itemText(i) for i in range(self.framework_combo.count())]:
             self.framework_combo.setCurrentText(self.framework_choice)
@@ -82,7 +80,6 @@ class MainWindow(QMainWindow):
         """Load saved configuration values into the instance."""
         data = load_config()
         self.project_path = data.get("project_path", self.project_path)
-        self.git_url = data.get("git_url", "")
         self.framework_choice = data.get("framework", self.framework_choice)
 
     def run_command(self, command):
@@ -149,11 +146,10 @@ class MainWindow(QMainWindow):
         self.log_view.setPlainText(log_contents.strip())
 
     def save_settings(self):
-        git_url = self.git_url_edit.text()
         project_path = self.project_path_edit.text()
         framework = self.framework_combo.currentText()
 
-        if not git_url or not project_path:
+        if not project_path:
             QMessageBox.warning(self, "Invalid settings", "All settings fields must be filled out.")
             print("Failed to save settings: one or more fields were empty")
             return
@@ -164,11 +160,9 @@ class MainWindow(QMainWindow):
             return
 
         self.project_path = project_path
-        self.git_url = git_url
         self.framework_choice = framework
 
         data = {
-            "git_url": git_url,
             "project_path": project_path,
             "framework": framework,
         }

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -18,9 +18,6 @@ class SettingsTab(QWidget):
 
         layout = QFormLayout(self)
 
-        self.git_url_edit = QLineEdit()
-        self.git_url_edit.setText(self.main_window.git_url)
-        layout.addRow("Git URL:", self.git_url_edit)
 
         self.project_path_edit = QLineEdit()
         self.project_path_edit.setText(self.main_window.project_path)
@@ -45,7 +42,6 @@ class SettingsTab(QWidget):
         layout.addRow(save_btn)
 
         # expose widgets for use in MainWindow
-        self.main_window.git_url_edit = self.git_url_edit
         self.main_window.project_path_edit = self.project_path_edit
         self.main_window.framework_combo = self.framework_combo
 


### PR DESCRIPTION
## Summary
- strip Git URL field from settings
- drop Git URL persistence from main window logic
- tweak docs to reflect updated settings

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`