### PR TITLE
Add PHP path config and phpunit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ the codebase easier to maintain. Each tab lives in its own file inside
 
 The available tabs are:
 
--   **Project** – buttons to manage migrations.
+-   **Project** – buttons to manage migrations and run PHPUnit tests.
 -   **Git** – simple controls for common Git actions.
 -   **Database** – quick actions for opening and dumping a database.
 -   **Logs** – shows your project's log file (Laravel only) with a refresh option.
--   **Settings** – fields for selecting the project directory and framework.
-    A _Browse_ button lets you pick the project directory.
+-   **Settings** – fields for selecting the project directory, framework and PHP executable.
+    Browse buttons let you choose each path.
 
-The application stores your selected project path and framework in
+The application stores your selected project path, PHP binary and framework in
 `~/.fusor_config.json`. These values are restored automatically when the
 application starts.
 

--- a/fusor/tabs/project_tab.py
+++ b/fusor/tabs/project_tab.py
@@ -28,3 +28,8 @@ class ProjectTab(QWidget):
         seed_btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         seed_btn.clicked.connect(self.main_window.seed)
         layout.addWidget(seed_btn)
+
+        phpunit_btn = QPushButton("PHPUnit")
+        phpunit_btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        phpunit_btn.clicked.connect(self.main_window.phpunit)
+        layout.addWidget(phpunit_btn)

--- a/fusor/tabs/project_tab.py
+++ b/fusor/tabs/project_tab.py
@@ -18,3 +18,8 @@ class ProjectTab(QWidget):
         stop_btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         stop_btn.clicked.connect(self.main_window.stop_project)
         layout.addWidget(stop_btn)
+
+        phpunit_btn = QPushButton("PHPUnit")
+        phpunit_btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        phpunit_btn.clicked.connect(self.main_window.phpunit)
+        layout.addWidget(phpunit_btn)

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -30,6 +30,17 @@ class SettingsTab(QWidget):
         path_layout.addWidget(browse_btn)
         layout.addRow("Project Path:", path_container)
 
+        self.php_path_edit = QLineEdit()
+        self.php_path_edit.setText(self.main_window.php_path)
+        php_container = QWidget()
+        php_layout = QHBoxLayout(php_container)
+        php_layout.setContentsMargins(0, 0, 0, 0)
+        php_layout.addWidget(self.php_path_edit)
+        php_browse_btn = QPushButton("Browse")
+        php_browse_btn.clicked.connect(self.browse_php_path)
+        php_layout.addWidget(php_browse_btn)
+        layout.addRow("PHP Executable:", php_container)
+
         self.framework_combo = QComboBox()
         self.framework_combo.addItems(["Laravel", "Yii", "None"])
         if self.main_window.framework_choice in ["Laravel", "Yii", "None"]:
@@ -44,6 +55,7 @@ class SettingsTab(QWidget):
         # expose widgets for use in MainWindow
         self.main_window.project_path_edit = self.project_path_edit
         self.main_window.framework_combo = self.framework_combo
+        self.main_window.php_path_edit = self.php_path_edit
 
     def browse_project_path(self):
         """Open a folder selection dialog and update the path field."""
@@ -54,4 +66,14 @@ class SettingsTab(QWidget):
         )
         if directory:
             self.project_path_edit.setText(directory)
+
+    def browse_php_path(self):
+        """Open a file selection dialog for the PHP executable."""
+        file, _ = QFileDialog.getOpenFileName(
+            self,
+            "Select PHP Executable",
+            self.php_path_edit.text() or self.main_window.php_path,
+        )
+        if file:
+            self.php_path_edit.setText(file)
 


### PR DESCRIPTION
## Summary
- let settings specify PHP executable
- store php path in config and use it for artisan
- add phpunit command and button in Project tab
- update README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`