### PR TITLE
Add start/stop controls and reorganize tabs

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -41,6 +41,8 @@ class MainWindow(QMainWindow):
 
         self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
+        self.server_process = None
+
         # Redirect stdout to the output view
         self._stdout_logger = QTextEditLogger(self.output_view, sys.stdout)
         sys.stdout = self._stdout_logger
@@ -205,7 +207,61 @@ class MainWindow(QMainWindow):
         else:
             print(f"Seed not implemented for {self.current_framework()}")
 
+    def start_project(self):
+        """Launch the project's development server."""
+        if self.server_process and self.server_process.poll() is None:
+            print("Project already running")
+            return
+
+        if not self.ensure_project_path():
+            return
+
+        if self.current_framework() == "Laravel":
+            artisan_file = os.path.join(self.project_path, "artisan")
+            command = ["php", artisan_file, "serve"]
+        else:
+            # fallback generic PHP server
+            command = ["php", "-S", "localhost:8000", "-t", os.path.join(self.project_path, "public")]
+
+        print(f"$ {' '.join(command)}")
+        try:
+            self.server_process = subprocess.Popen(
+                command,
+                cwd=self.project_path,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+
+            def stream():
+                assert self.server_process is not None
+                for line in self.server_process.stdout:
+                    print(line.rstrip())
+
+            self.executor.submit(stream)
+        except FileNotFoundError:
+            print(f"Command not found: {command[0]}")
+
+    def stop_project(self):
+        """Terminate the running development server."""
+        if self.server_process and self.server_process.poll() is None:
+            print("Stopping project...")
+            self.server_process.terminate()
+            try:
+                self.server_process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.server_process.kill()
+            self.server_process = None
+        else:
+            print("Project is not running")
+
     def closeEvent(self, event):
         """Shutdown background executor before closing."""
+        if self.server_process and self.server_process.poll() is None:
+            self.server_process.terminate()
+            try:
+                self.server_process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.server_process.kill()
         self.executor.shutdown(wait=False)
         super().closeEvent(event)

--- a/fusor/tabs/database_tab.py
+++ b/fusor/tabs/database_tab.py
@@ -23,3 +23,23 @@ class DatabaseTab(QWidget):
         restore_btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         restore_btn.clicked.connect(lambda: print("Restore dump clicked"))
         layout.addWidget(restore_btn)
+
+        migrate_btn = QPushButton("Migrate")
+        migrate_btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        migrate_btn.clicked.connect(self.main_window.migrate)
+        layout.addWidget(migrate_btn)
+
+        rollback_btn = QPushButton("Rollback")
+        rollback_btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        rollback_btn.clicked.connect(self.main_window.rollback)
+        layout.addWidget(rollback_btn)
+
+        fresh_btn = QPushButton("Fresh")
+        fresh_btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        fresh_btn.clicked.connect(self.main_window.fresh)
+        layout.addWidget(fresh_btn)
+
+        seed_btn = QPushButton("Seed")
+        seed_btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        seed_btn.clicked.connect(self.main_window.seed)
+        layout.addWidget(seed_btn)

--- a/fusor/tabs/project_tab.py
+++ b/fusor/tabs/project_tab.py
@@ -1,7 +1,7 @@
 from PyQt6.QtWidgets import QWidget, QVBoxLayout, QPushButton, QSizePolicy
 
 class ProjectTab(QWidget):
-    """Tab with common project migration actions."""
+    """Tab with common project actions."""
 
     def __init__(self, main_window):
         super().__init__()
@@ -9,22 +9,12 @@ class ProjectTab(QWidget):
 
         layout = QVBoxLayout(self)
 
-        migrate_btn = QPushButton("Migrate")
-        migrate_btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-        migrate_btn.clicked.connect(self.main_window.migrate)
-        layout.addWidget(migrate_btn)
+        start_btn = QPushButton("Start")
+        start_btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        start_btn.clicked.connect(self.main_window.start_project)
+        layout.addWidget(start_btn)
 
-        rollback_btn = QPushButton("Rollback")
-        rollback_btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-        rollback_btn.clicked.connect(self.main_window.rollback)
-        layout.addWidget(rollback_btn)
-
-        fresh_btn = QPushButton("Fresh")
-        fresh_btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-        fresh_btn.clicked.connect(self.main_window.fresh)
-        layout.addWidget(fresh_btn)
-
-        seed_btn = QPushButton("Seed")
-        seed_btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-        seed_btn.clicked.connect(self.main_window.seed)
-        layout.addWidget(seed_btn)
+        stop_btn = QPushButton("Stop")
+        stop_btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        stop_btn.clicked.connect(self.main_window.stop_project)
+        layout.addWidget(stop_btn)


### PR DESCRIPTION
## Summary
- move migrate/fresh/rollback/seed buttons to the Database tab
- add Start and Stop buttons to the Project tab
- implement `start_project` and `stop_project` helpers in `MainWindow`
- ensure development server is terminated on exit

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`