### PR TITLE
Fix early exit in refresh_logs

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -128,7 +128,8 @@ class MainWindow(QMainWindow):
     def refresh_logs(self):
         print("Refresh logs clicked")
 
-        self.ensure_project_path()
+        if not self.ensure_project_path():
+            return
 
         framework = self.current_framework()
         log_contents = ""

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -1,5 +1,8 @@
 import builtins
 import os
+# Force Qt to use the offscreen platform before importing QApplication to avoid
+# errors on systems without a display server or OpenGL libraries.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 from PyQt6.QtWidgets import QApplication
 import fusor.main_window as mw_module
 from fusor.main_window import MainWindow
@@ -11,7 +14,6 @@ class DummyLogView:
         self.text = text
 
 def test_refresh_logs_no_project_path(monkeypatch):
-    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     app = QApplication.instance()
     if app is None:
         app = QApplication([])

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -1,0 +1,41 @@
+import builtins
+import os
+from PyQt6.QtWidgets import QApplication
+import fusor.main_window as mw_module
+from fusor.main_window import MainWindow
+
+class DummyLogView:
+    def __init__(self):
+        self.text = None
+    def setPlainText(self, text):
+        self.text = text
+
+def test_refresh_logs_no_project_path(monkeypatch):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+
+    # prevent dialog on construction
+    monkeypatch.setattr(mw_module.QTimer, "singleShot", lambda *a, **k: None)
+    monkeypatch.setattr(MainWindow, "ask_project_path", lambda self: None)
+    # avoid reading real config
+    monkeypatch.setattr(mw_module, "load_config", lambda: {})
+
+    window = MainWindow()
+    window.project_path = ""
+    dummy = DummyLogView()
+    window.log_view = dummy
+    close_called = []
+    monkeypatch.setattr(window, "close", lambda: close_called.append(True))
+
+    def fail(*args, **kwargs):
+        raise AssertionError("log access attempted")
+
+    monkeypatch.setattr(os.path, "exists", fail)
+    monkeypatch.setattr(builtins, "open", fail)
+
+    window.refresh_logs()
+
+    assert close_called == [True]
+    assert dummy.text is None


### PR DESCRIPTION
## Summary
- return early from `MainWindow.refresh_logs` when no project path is configured
- add regression test ensuring log files aren't touched when the project path is missing

## Testing
- `pytest -q`