### PR TITLE
Use configured php path when launching server

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -234,10 +234,10 @@ class MainWindow(QMainWindow):
 
         if self.current_framework() == "Laravel":
             artisan_file = os.path.join(self.project_path, "artisan")
-            command = ["php", artisan_file, "serve"]
+            command = [self.php_path, artisan_file, "serve"]
         else:
             # fallback generic PHP server
-            command = ["php", "-S", "localhost:8000", "-t", os.path.join(self.project_path, "public")]
+            command = [self.php_path, "-S", "localhost:8000", "-t", os.path.join(self.project_path, "public")]
 
         print(f"$ {' '.join(command)}")
         try:

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -1,0 +1,41 @@
+import os
+import subprocess
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+from PyQt6.QtWidgets import QApplication
+from fusor.main_window import MainWindow
+
+
+def test_start_project_uses_configured_php(tmp_path, monkeypatch):
+    # ensure QApplication exists for MainWindow
+    app = QApplication.instance() or QApplication([])
+
+    window = MainWindow()
+    window.project_path = str(tmp_path)
+    window.framework_choice = "None"
+    if hasattr(window, "framework_combo"):
+        window.framework_combo.setCurrentText("None")
+    window.php_path = "/custom/php"
+
+    (tmp_path / "public").mkdir()
+
+    called = {}
+
+    class DummyProcess:
+        def __init__(self):
+            self.stdout = []
+
+        def poll(self):
+            return None
+
+    def fake_popen(cmd, **kwargs):
+        called["cmd"] = cmd
+        return DummyProcess()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(window.executor, "submit", lambda fn: None)
+
+    window.start_project()
+
+    assert called["cmd"][0] == "/custom/php"
+
+    app.quit()


### PR DESCRIPTION
## Summary
- use `self.php_path` when constructing server command
- test that `start_project` respects configured PHP path

## Testing
- `pytest -q`