### PR TITLE
Add optional auto refresh for Logs tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@ The available tabs are:
 -   **Project** – buttons to manage migrations and run PHPUnit tests.
 -   **Git** – simple controls for common Git actions.
 -   **Database** – quick actions for opening and dumping a database.
--   **Logs** – shows your project's log file (Laravel only) with a refresh option.
+-   **Logs** – shows your project's log file (Laravel only) with a refresh
+    button and optional auto refresh.
 -   **Settings** – fields for selecting the project directory, framework and PHP executable.
     Browse buttons let you choose each path.
+
+The Logs tab also provides an **Auto refresh** checkbox to reload logs
+automatically every few seconds.
 
 The application stores your selected project path, PHP binary, framework and the
 "use docker" setting in

--- a/fusor/tabs/logs_tab.py
+++ b/fusor/tabs/logs_tab.py
@@ -1,4 +1,12 @@
-from PyQt6.QtWidgets import QWidget, QVBoxLayout, QTextEdit, QPushButton, QSizePolicy
+from PyQt6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QTextEdit,
+    QPushButton,
+    QCheckBox,
+    QSizePolicy,
+)
+from PyQt6.QtCore import QTimer
 
 class LogsTab(QWidget):
     """Tab that displays log text and allows refreshing."""
@@ -21,5 +29,23 @@ class LogsTab(QWidget):
         refresh_btn.clicked.connect(self.main_window.refresh_logs)
         layout.addWidget(refresh_btn)
 
+        self.auto_checkbox = QCheckBox("Auto refresh")
+        self.auto_checkbox.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+        )
+        layout.addWidget(self.auto_checkbox)
+
+        self._timer = QTimer(self)
+        self._timer.setInterval(5000)
+        self._timer.timeout.connect(self.main_window.refresh_logs)
+        self.auto_checkbox.toggled.connect(self.on_auto_refresh_toggled)
+
         # expose log view so main window can update it
         self.main_window.log_view = self.log_view
+
+    def on_auto_refresh_toggled(self, checked: bool):
+        if checked:
+            self._timer.start()
+            self.main_window.refresh_logs()
+        else:
+            self._timer.stop()


### PR DESCRIPTION
## Summary
- add checkbox in Logs tab to trigger timed auto refresh
- update README with description of new feature

## Testing
- `pip install -q PyQt6 pytest`
- `pip install -q pytest-qt`
- `export QT_QPA_PLATFORM=offscreen`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873a1c3aa248322815721bbba31a98d