### PR TITLE
Add PHP service setting for Docker usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ The available tabs are:
 -   **Database** – quick actions for opening and dumping a database.
 -   **Logs** – shows your project's log file (Laravel only) with a refresh
     button and optional auto refresh.
--   **Settings** – fields for selecting the project directory, framework and PHP executable.
-    Browse buttons let you choose each path.
+-   **Settings** – fields for selecting the project directory, framework and PHP
+    executable or Docker service name. Browse buttons let you choose each path.
 
 The Logs tab also provides an **Auto refresh** checkbox to reload logs
 automatically every few seconds.
 
-The application stores your selected project path, PHP binary, framework and the
-"use docker" setting in
+The application stores your selected project path, PHP binary, framework,
+Docker service name and the "use docker" setting in
 `~/.fusor_config.json`. These values are restored automatically when the
 application starts.
 
@@ -40,6 +40,8 @@ python3 main.py
 Enable the **Use Docker** option in the Settings tab to run all PHP commands
 inside your project's Docker containers. When enabled, actions such as running
 PHPUnit or starting the development server are executed via `docker compose`.
+Set the **PHP Service** field to the name of the service running PHP so
+`docker compose exec` uses the correct container.
 The Start and Stop buttons will run `docker compose up -d` and `docker compose
 down` respectively.
 

--- a/fusor/config.py
+++ b/fusor/config.py
@@ -10,14 +10,15 @@ def load_config():
         with open(CONFIG_FILE, "r", encoding="utf-8") as f:
             data = json.load(f)
         if not isinstance(data, dict):
-            return {"use_docker": False}
+            return {"use_docker": False, "php_service": "php"}
         data.setdefault("use_docker", False)
+        data.setdefault("php_service", "php")
         return data
     except FileNotFoundError:
-        return {"use_docker": False}
+        return {"use_docker": False, "php_service": "php"}
     except json.JSONDecodeError:
         print("Failed to load config: invalid JSON")
-        return {"use_docker": False}
+        return {"use_docker": False, "php_service": "php"}
 
 def save_config(data):
     """Persist configuration dictionary to disk."""

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -55,6 +55,7 @@ class MainWindow(QMainWindow):
         self.project_path = ""
         self.framework_choice = "Laravel"
         self.php_path = "php"
+        self.php_service = "php"
         self.use_docker = False
         self.load_config()
 
@@ -90,6 +91,7 @@ class MainWindow(QMainWindow):
         self.project_path = data.get("project_path", self.project_path)
         self.framework_choice = data.get("framework", self.framework_choice)
         self.php_path = data.get("php_path", self.php_path)
+        self.php_service = data.get("php_service", self.php_service)
         self.use_docker = data.get("use_docker", self.use_docker)
 
     def run_command(self, command):
@@ -103,7 +105,7 @@ class MainWindow(QMainWindow):
                 "compose",
                 "exec",
                 "-T",
-                "php",
+                self.php_service,
                 *command,
             ]
         cwd = self.project_path if self.use_docker else None
@@ -173,9 +175,10 @@ class MainWindow(QMainWindow):
         project_path = self.project_path_edit.text()
         framework = self.framework_combo.currentText()
         php_path = self.php_path_edit.text()
+        php_service = self.php_service_edit.text() if hasattr(self, "php_service_edit") else self.php_service
         use_docker = self.docker_checkbox.isChecked()
 
-        if not project_path or (not php_path and not use_docker):
+        if not project_path or (not php_path and not use_docker) or (use_docker and not php_service):
             QMessageBox.warning(self, "Invalid settings", "All settings fields must be filled out.")
             print("Failed to save settings: one or more fields were empty")
             return
@@ -193,12 +196,14 @@ class MainWindow(QMainWindow):
         self.project_path = project_path
         self.framework_choice = framework
         self.php_path = php_path
+        self.php_service = php_service or self.php_service
         self.use_docker = use_docker
 
         data = {
             "project_path": project_path,
             "framework": framework,
             "php_path": php_path,
+            "php_service": php_service,
             "use_docker": use_docker,
         }
         try:

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -41,6 +41,10 @@ class SettingsTab(QWidget):
         php_layout.addWidget(self.php_browse_btn)
         layout.addRow("PHP Executable:", php_container)
 
+        self.php_service_edit = QLineEdit()
+        self.php_service_edit.setText(self.main_window.php_service)
+        layout.addRow("PHP Service:", self.php_service_edit)
+
         self.framework_combo = QComboBox()
         self.framework_combo.addItems(["Laravel", "Yii", "None"])
         if self.main_window.framework_choice in ["Laravel", "Yii", "None"]:
@@ -61,6 +65,7 @@ class SettingsTab(QWidget):
         self.main_window.project_path_edit = self.project_path_edit
         self.main_window.framework_combo = self.framework_combo
         self.main_window.php_path_edit = self.php_path_edit
+        self.main_window.php_service_edit = self.php_service_edit
         self.main_window.docker_checkbox = self.docker_checkbox
 
         # apply initial enabled state
@@ -70,6 +75,7 @@ class SettingsTab(QWidget):
         """Enable or disable PHP path widgets when Docker mode changes."""
         self.php_path_edit.setEnabled(not checked)
         self.php_browse_btn.setEnabled(not checked)
+        self.php_service_edit.setEnabled(checked)
 
     def browse_project_path(self):
         """Open a folder selection dialog and update the path field."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ from fusor import config
 def test_save_then_load(tmp_path, monkeypatch):
     cfg_file = tmp_path / "config.json"
     monkeypatch.setattr(config, "CONFIG_FILE", str(cfg_file))
-    data = {"foo": 123, "bar": [1, 2, 3], "use_docker": True}
+    data = {"foo": 123, "bar": [1, 2, 3], "use_docker": True, "php_service": "php"}
     config.save_config(data)
     loaded = config.load_config()
     assert loaded == data
@@ -11,10 +11,10 @@ def test_save_then_load(tmp_path, monkeypatch):
 def test_load_missing_file(tmp_path, monkeypatch):
     cfg_file = tmp_path / "missing.json"
     monkeypatch.setattr(config, "CONFIG_FILE", str(cfg_file))
-    assert config.load_config() == {"use_docker": False}
+    assert config.load_config() == {"use_docker": False, "php_service": "php"}
 
 def test_load_invalid_json(tmp_path, monkeypatch):
     cfg_file = tmp_path / "broken.json"
     cfg_file.write_text("{ invalid json")
     monkeypatch.setattr(config, "CONFIG_FILE", str(cfg_file))
-    assert config.load_config() == {"use_docker": False}
+    assert config.load_config() == {"use_docker": False, "php_service": "php"}


### PR DESCRIPTION
## Summary
- allow configuring the PHP service name used with Docker
- persist php_service in config
- update settings UI for php_service and toggle enable state
- document new Docker setting in README
- test new behaviour

## Testing
- `pip install -q -r requirements.txt -r requirements-dev.txt`
- `apt-get update -y`
- `apt-get install -y libegl1 libgl1 libxkbcommon-x11-0`
- `export QT_QPA_PLATFORM=offscreen`
- `pytest -q`