### PR TITLE
Add headless config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ down` respectively.
 
 ## Testing
 
-Install pytest and run the test suite from the repository root:
+Install pytest and run the test suite from the repository root. Tests run
+headless automatically thanks to the `QT_QPA_PLATFORM=offscreen` setting in
+`pytest.ini`:
 
 ```bash
 pip install pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+env =
+    QT_QPA_PLATFORM=offscreen


### PR DESCRIPTION
## Summary
- make PyQt tests run headless using QT_QPA_PLATFORM=offscreen
- document that tests run headless automatically

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q` *(fails: ProjectTab object has no attribute composer_install_btn)*