### PR TITLE
Add database tab actions and tests

### DIFF
--- a/fusor/tabs/database_tab.py
+++ b/fusor/tabs/database_tab.py
@@ -1,5 +1,10 @@
 from PyQt6.QtWidgets import (
-    QWidget, QVBoxLayout, QPushButton, QSizePolicy, QGroupBox
+    QWidget,
+    QVBoxLayout,
+    QPushButton,
+    QSizePolicy,
+    QGroupBox,
+    QFileDialog,
 )
 
 class DatabaseTab(QWidget):
@@ -15,13 +20,13 @@ class DatabaseTab(QWidget):
         tools_layout = QVBoxLayout()
         tools_layout.setSpacing(10)
 
-        dbeaver_btn = self._btn("🧩 Open in DBeaver", lambda: print("Open in DBeaver clicked"))
-        dump_btn = self._btn("💾 Dump to SQL", lambda: print("Dump to SQL clicked"))
-        restore_btn = self._btn("📂 Restore dump", lambda: print("Restore dump clicked"))
+        self.dbeaver_btn = self._btn("🧩 Open in DBeaver", self.open_dbeaver)
+        self.dump_btn = self._btn("💾 Dump to SQL", self.dump_sql)
+        self.restore_btn = self._btn("📂 Restore dump", self.restore_dump)
 
-        tools_layout.addWidget(dbeaver_btn)
-        tools_layout.addWidget(dump_btn)
-        tools_layout.addWidget(restore_btn)
+        tools_layout.addWidget(self.dbeaver_btn)
+        tools_layout.addWidget(self.dump_btn)
+        tools_layout.addWidget(self.restore_btn)
 
         tools_group.setLayout(tools_layout)
         outer_layout.addWidget(tools_group)
@@ -47,3 +52,16 @@ class DatabaseTab(QWidget):
         btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         btn.clicked.connect(slot)
         return btn
+
+    def open_dbeaver(self):
+        self.main_window.run_command(["dbeaver"])
+
+    def dump_sql(self):
+        path, _ = QFileDialog.getSaveFileName(self, "Save SQL Dump", filter="SQL Files (*.sql)")
+        if path:
+            self.main_window.run_command(["mysqldump", "--result-file", path])
+
+    def restore_dump(self):
+        path, _ = QFileDialog.getOpenFileName(self, "Select SQL Dump", filter="SQL Files (*.sql)")
+        if path:
+            self.main_window.run_command(["mysql", path])

--- a/fusor/tabs/project_tab.py
+++ b/fusor/tabs/project_tab.py
@@ -22,6 +22,7 @@ class ProjectTab(QWidget):
         layout.addLayout(row1)
 
         layout.addWidget(self._btn("Run PHPUnit", main_window.phpunit))
+
         self.composer_install_btn = self._btn(
             "Composer install",
             lambda: main_window.run_command(["composer", "install"]),

--- a/fusor/tabs/project_tab.py
+++ b/fusor/tabs/project_tab.py
@@ -22,8 +22,17 @@ class ProjectTab(QWidget):
         layout.addLayout(row1)
 
         layout.addWidget(self._btn("Run PHPUnit", main_window.phpunit))
-        layout.addWidget(self._btn("Composer install", lambda: main_window.run_command(["composer", "install"])))
-        layout.addWidget(self._btn("Composer update", lambda: main_window.run_command(["composer", "update"])))
+        self.composer_install_btn = self._btn(
+            "Composer install",
+            lambda: main_window.run_command(["composer", "install"]),
+        )
+        layout.addWidget(self.composer_install_btn)
+
+        self.composer_update_btn = self._btn(
+            "Composer update",
+            lambda: main_window.run_command(["composer", "update"]),
+        )
+        layout.addWidget(self.composer_update_btn)
 
         layout.addStretch(1)
 

--- a/fusor/tabs/project_tab.py
+++ b/fusor/tabs/project_tab.py
@@ -22,7 +22,6 @@ class ProjectTab(QWidget):
         layout.addLayout(row1)
 
         layout.addWidget(self._btn("Run PHPUnit", main_window.phpunit))
-        
         self.composer_install_btn = self._btn(
             "Composer install",
             lambda: main_window.run_command(["composer", "install"]),

--- a/tests/test_database_tab.py
+++ b/tests/test_database_tab.py
@@ -1,0 +1,59 @@
+import pytest
+from PyQt6.QtCore import Qt
+
+from fusor.tabs.database_tab import DatabaseTab
+
+
+class DummyMainWindow:
+    def __init__(self):
+        self.commands = []
+        # stubs used by migration buttons but not tested here
+        self.migrate = lambda: None
+        self.rollback = lambda: None
+        self.fresh = lambda: None
+        self.seed = lambda: None
+
+    def run_command(self, cmd):
+        self.commands.append(cmd)
+
+
+def test_dbeaver_button_runs_command(monkeypatch, qtbot):
+    main = DummyMainWindow()
+    tab = DatabaseTab(main)
+    qtbot.addWidget(tab)
+
+    qtbot.mouseClick(tab.dbeaver_btn, Qt.MouseButton.LeftButton)
+
+    assert main.commands == [["dbeaver"]]
+
+
+def test_dump_button_runs_command(monkeypatch, qtbot):
+    main = DummyMainWindow()
+    tab = DatabaseTab(main)
+    qtbot.addWidget(tab)
+
+    monkeypatch.setattr(
+        "PyQt6.QtWidgets.QFileDialog.getSaveFileName",
+        lambda *a, **k: ("/tmp/d.sql", ""),
+        raising=True,
+    )
+
+    qtbot.mouseClick(tab.dump_btn, Qt.MouseButton.LeftButton)
+
+    assert main.commands == [["mysqldump", "--result-file", "/tmp/d.sql"]]
+
+
+def test_restore_button_runs_command(monkeypatch, qtbot):
+    main = DummyMainWindow()
+    tab = DatabaseTab(main)
+    qtbot.addWidget(tab)
+
+    monkeypatch.setattr(
+        "PyQt6.QtWidgets.QFileDialog.getOpenFileName",
+        lambda *a, **k: ("/tmp/d.sql", ""),
+        raising=True,
+    )
+
+    qtbot.mouseClick(tab.restore_btn, Qt.MouseButton.LeftButton)
+
+    assert main.commands == [["mysql", "/tmp/d.sql"]]


### PR DESCRIPTION
## Summary
- implement database tab actions using `run_command`
- expose composer buttons on the project tab
- add tests for the database tab buttons

## Testing
- `pytest -q`