### PR TITLE
Fix E402 ordering and clean unused imports

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -3,9 +3,6 @@ import os
 import subprocess
 import concurrent.futures
 import builtins
-
-# allow tests to monkeypatch file operations easily
-open = builtins.open
 from PyQt6.QtWidgets import (
     QMainWindow,
     QTabWidget,
@@ -25,6 +22,9 @@ from .tabs.git_tab import GitTab
 from .tabs.database_tab import DatabaseTab
 from .tabs.logs_tab import LogsTab
 from .tabs.settings_tab import SettingsTab
+
+# allow tests to monkeypatch file operations easily
+open = builtins.open
 
 class MainWindow(QMainWindow):
     def __init__(self):

--- a/tests/test_database_tab.py
+++ b/tests/test_database_tab.py
@@ -1,4 +1,3 @@
-import pytest
 from PyQt6.QtCore import Qt
 
 from fusor.tabs.database_tab import DatabaseTab

--- a/tests/test_git_tab.py
+++ b/tests/test_git_tab.py
@@ -1,7 +1,6 @@
 import subprocess
 from PyQt6.QtWidgets import QMessageBox
 
-import fusor.tabs.git_tab as gt_module
 from fusor.tabs.git_tab import GitTab
 
 

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -1,4 +1,3 @@
-import builtins
 import os
 import subprocess
 from pathlib import Path


### PR DESCRIPTION
## Summary
- ensure main_window's `open` assignment follows all imports
- clean unused imports in database, git, and main window tests
- run ruff to ensure code style compliance

## Testing
- `ruff check .`
- `pytest -q` *(fails: Fatal Python error: Aborted)*