### PR TITLE
Add pyproject and console entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,14 @@ application starts.
 
 ## Running
 
-Install the dependencies from `requirements.txt` and execute `main.py`:
+Install the dependencies from `requirements.txt` and run the application using
+the provided console script:
 
 ```bash
 pip install -r requirements.txt
-python3 main.py
+fusor
+# or
+python3 -m fusor
 ```
 
 ### Docker mode

--- a/fusor/__main__.py
+++ b/fusor/__main__.py
@@ -1,0 +1,15 @@
+import sys
+from PyQt6.QtWidgets import QApplication
+
+from .main_window import MainWindow
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,14 +1,4 @@
-import sys
-from PyQt6.QtWidgets import QApplication
-
-from fusor.main_window import MainWindow
-
-def main():
-    app = QApplication(sys.argv)
-    window = MainWindow()
-    window.show()
-    sys.exit(app.exec())
-
+from fusor.__main__ import main
 
 if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "fusor"
+version = "0.1.0"
+description = "A minimal PyQt6 application with helper tools for PHP development."
+authors = [{name = "Fusor Dev"}]
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "PyQt6~=6.9"
+]
+
+[project.scripts]
+fusor = "fusor.__main__:main"


### PR DESCRIPTION
## Summary
- add `pyproject.toml` with project metadata and console script
- move executable logic into `fusor/__main__.py`
- delegate `main.py` to new module
- document using the `fusor` command in README

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -q`