### PR TITLE
Add Yii template setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ The available tabs are:
 -   **Logs** – shows your project's log file (Laravel only) with a refresh
     button and optional auto refresh.
 -   **Settings** – fields for selecting the project directory, framework and PHP
-    executable or Docker service name. Browse buttons let you choose each path.
+    executable or Docker service name. When **Yii** is selected, a drop-down
+    lets you choose between the **basic** or **advanced** application template.
+    Browse buttons let you choose each path.
 
 The Logs tab also provides an **Auto refresh** checkbox to reload logs
 automatically every few seconds.
 
 The application stores your selected project path, PHP binary, framework,
-Docker service name and the "use docker" setting in
+Yii template, Docker service name and the "use docker" setting in
 `~/.fusor_config.json`. These values are restored automatically when the
 application starts.
 

--- a/fusor/config.py
+++ b/fusor/config.py
@@ -10,15 +10,16 @@ def load_config():
         with open(CONFIG_FILE, "r", encoding="utf-8") as f:
             data = json.load(f)
         if not isinstance(data, dict):
-            return {"use_docker": False, "php_service": "php"}
+            return {"use_docker": False, "php_service": "php", "yii_template": "basic"}
         data.setdefault("use_docker", False)
         data.setdefault("php_service", "php")
+        data.setdefault("yii_template", "basic")
         return data
     except FileNotFoundError:
-        return {"use_docker": False, "php_service": "php"}
+        return {"use_docker": False, "php_service": "php", "yii_template": "basic"}
     except json.JSONDecodeError:
         print("Failed to load config: invalid JSON")
-        return {"use_docker": False, "php_service": "php"}
+        return {"use_docker": False, "php_service": "php", "yii_template": "basic"}
 
 def save_config(data):
     """Persist configuration dictionary to disk."""

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -151,6 +151,7 @@ class MainWindow(QMainWindow):
         self.php_path = "php"
         self.php_service = "php"
         self.use_docker = False
+        self.yii_template = "basic"
         self.load_config()
 
         # initialize tabs
@@ -186,6 +187,7 @@ class MainWindow(QMainWindow):
         self.php_path = data.get("php_path", self.php_path)
         self.php_service = data.get("php_service", self.php_service)
         self.use_docker = data.get("use_docker", self.use_docker)
+        self.yii_template = data.get("yii_template", self.yii_template)
 
     def run_command(self, command):
         if self.use_docker and not (
@@ -264,6 +266,7 @@ class MainWindow(QMainWindow):
         php_path = self.php_path_edit.text()
         php_service = self.php_service_edit.text() if hasattr(self, "php_service_edit") else self.php_service
         use_docker = self.docker_checkbox.isChecked()
+        yii_template = self.yii_template_combo.currentText() if hasattr(self, "yii_template_combo") else self.yii_template
 
         if not project_path or (not php_path and not use_docker) or (use_docker and not php_service):
             QMessageBox.warning(self, "Invalid settings", "All settings fields must be filled out.")
@@ -285,6 +288,7 @@ class MainWindow(QMainWindow):
         self.php_path = php_path
         self.php_service = php_service or self.php_service
         self.use_docker = use_docker
+        self.yii_template = yii_template
 
         data = {
             "project_path": project_path,
@@ -292,6 +296,7 @@ class MainWindow(QMainWindow):
             "php_path": php_path,
             "php_service": php_service,
             "use_docker": use_docker,
+            "yii_template": yii_template,
         }
         try:
             save_config(data)

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -52,7 +52,15 @@ class SettingsTab(QWidget):
         self.framework_combo.addItems(["Laravel", "Yii", "None"])
         if self.main_window.framework_choice in ["Laravel", "Yii", "None"]:
             self.framework_combo.setCurrentText(self.main_window.framework_choice)
+        self.framework_combo.currentTextChanged.connect(self.on_framework_changed)
         form.addRow("Framework:", self.framework_combo)
+
+        self.yii_template_combo = QComboBox()
+        self.yii_template_combo.addItems(["basic", "advanced"])
+        if hasattr(self.main_window, "yii_template"):
+            self.yii_template_combo.setCurrentText(self.main_window.yii_template)
+        self.yii_template_row = self._wrap(self.yii_template_combo)
+        form.addRow("Yii Template:", self.yii_template_row)
 
         self.docker_checkbox = QCheckBox("Use Docker")
         self.docker_checkbox.setChecked(self.main_window.use_docker)
@@ -74,8 +82,10 @@ class SettingsTab(QWidget):
         self.main_window.php_path_edit = self.php_path_edit
         self.main_window.php_service_edit = self.php_service_edit
         self.main_window.docker_checkbox = self.docker_checkbox
+        self.main_window.yii_template_combo = self.yii_template_combo
 
         self.on_docker_toggled(self.docker_checkbox.isChecked())
+        self.on_framework_changed(self.framework_combo.currentText())
 
     def _wrap(self, layout):
         container = QWidget()
@@ -104,4 +114,7 @@ class SettingsTab(QWidget):
         )
         if file:
             self.php_path_edit.setText(file)
+
+    def on_framework_changed(self, text: str):
+        self.yii_template_row.setVisible(text == "Yii")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ from fusor import config
 def test_save_then_load(tmp_path, monkeypatch):
     cfg_file = tmp_path / "config.json"
     monkeypatch.setattr(config, "CONFIG_FILE", str(cfg_file))
-    data = {"foo": 123, "bar": [1, 2, 3], "use_docker": True, "php_service": "php"}
+    data = {"foo": 123, "bar": [1, 2, 3], "use_docker": True, "php_service": "php", "yii_template": "advanced"}
     config.save_config(data)
     loaded = config.load_config()
     assert loaded == data
@@ -11,10 +11,10 @@ def test_save_then_load(tmp_path, monkeypatch):
 def test_load_missing_file(tmp_path, monkeypatch):
     cfg_file = tmp_path / "missing.json"
     monkeypatch.setattr(config, "CONFIG_FILE", str(cfg_file))
-    assert config.load_config() == {"use_docker": False, "php_service": "php"}
+    assert config.load_config() == {"use_docker": False, "php_service": "php", "yii_template": "basic"}
 
 def test_load_invalid_json(tmp_path, monkeypatch):
     cfg_file = tmp_path / "broken.json"
     cfg_file.write_text("{ invalid json")
     monkeypatch.setattr(config, "CONFIG_FILE", str(cfg_file))
-    assert config.load_config() == {"use_docker": False, "php_service": "php"}
+    assert config.load_config() == {"use_docker": False, "php_service": "php", "yii_template": "basic"}


### PR DESCRIPTION
## Summary
- add dropdown for Yii template selection
- store `yii_template` in configuration and load/save
- document new setting in README
- update tests for config defaults

## Testing
- `pytest -q` *(fails: PyQt triggers fatal error)*

------
https://chatgpt.com/codex/tasks/task_e_6874d28848848322ba776a3030afabe6