### PR TITLE
Fix SettingsTab widget wrapper

### DIFF
--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -10,6 +10,7 @@ from PyQt6.QtWidgets import (
     QCheckBox,
     QVBoxLayout,
     QGroupBox,
+    QLayout,
 )
 
 from PyQt6.QtCore import Qt
@@ -91,9 +92,15 @@ class SettingsTab(QWidget):
         self.on_docker_toggled(self.docker_checkbox.isChecked())
         self.on_framework_changed(self.framework_combo.currentText())
 
-    def _wrap(self, layout):
+    def _wrap(self, child):
+        """Return a QWidget containing the given layout or widget."""
         container = QWidget()
-        container.setLayout(layout)
+        if isinstance(child, QLayout):
+            container.setLayout(child)
+        else:
+            layout = QHBoxLayout()
+            layout.addWidget(child)
+            container.setLayout(layout)
         return container
 
     def on_docker_toggled(self, checked: bool):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+
+# Ensure Qt operates in offscreen mode during tests
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")


### PR DESCRIPTION
## Summary
- fix `_wrap` helper to handle widgets or layouts correctly
- ensure tests run in headless mode by default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874db4f1c348322801df79d7880673f