### PR TITLE
Hide Yii template row when not using Yii

### DIFF
--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -11,6 +11,7 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
     QGroupBox,
     QLayout,
+    QLabel,
 )
 
 from PyQt6.QtCore import Qt
@@ -74,7 +75,8 @@ class SettingsTab(QWidget):
         if hasattr(self.main_window, "yii_template"):
             self.yii_template_combo.setCurrentText(self.main_window.yii_template)
         self.yii_template_row = self._wrap(self.yii_template_combo)
-        form.addRow("Yii Template:", self.yii_template_row)
+        self.yii_template_label = QLabel("Yii Template:")
+        form.addRow(self.yii_template_label, self.yii_template_row)
 
         self.docker_checkbox = QCheckBox("Use Docker")
         self.docker_checkbox.setChecked(self.main_window.use_docker)
@@ -147,6 +149,8 @@ class SettingsTab(QWidget):
             self.log_path_edit.setText(file)
 
     def on_framework_changed(self, text: str):
-        self.yii_template_row.setVisible(text == "Yii")
+        visible = text == "Yii"
+        self.yii_template_row.setVisible(visible)
+        self.yii_template_label.setVisible(visible)
         self.log_path_row.setVisible(text == "Laravel")
 

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -217,3 +217,14 @@ class TestMainWindow:
 
         assert opened == [str(log_file)]
         assert main_window.log_view.text == "log text"
+
+    def test_yii_template_row_visibility(self, main_window, qtbot):
+        main_window.framework_combo.setCurrentText("None")
+        qtbot.wait(10)
+        assert main_window.settings_tab.yii_template_row.isHidden()
+        assert main_window.settings_tab.yii_template_label.isHidden()
+
+        main_window.framework_combo.setCurrentText("Yii")
+        qtbot.wait(10)
+        assert not main_window.settings_tab.yii_template_row.isHidden()
+        assert not main_window.settings_tab.yii_template_label.isHidden()


### PR DESCRIPTION
## Summary
- hide both label and row for Yii template when Framework not set to Yii
- test visibility toggling of Yii template widgets

## Testing
- `ruff check`
- `mypy fusor`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875056e7ea483229554abc64926cad9