### PR TITLE
Add Docker helper tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The available tabs are:
 -   **Project** – buttons to manage migrations and run PHPUnit tests.
 -   **Git** – simple controls for common Git actions.
 -   **Database** – quick actions for opening and dumping a database.
+-   **Docker** – helpers for building, pulling and inspecting containers.
 -   **Logs** – shows your project's log file (Laravel only) with a refresh
     button and optional auto refresh.
 -   **Settings** – fields for selecting the project directory, framework, PHP
@@ -53,6 +54,9 @@ Set the **PHP Service** field to the name of the service running PHP so
 `docker compose exec` uses the correct container.
 The Start and Stop buttons will run `docker compose up -d` and `docker compose
 down` respectively.
+The new **Docker** tab becomes active in this mode and lets you rebuild
+images, pull updates, inspect container status, view logs and restart
+services with a single click.
 
 ## Testing
 

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -20,6 +20,7 @@ from .qtextedit_logger import QTextEditLogger
 from .tabs.project_tab import ProjectTab
 from .tabs.git_tab import GitTab
 from .tabs.database_tab import DatabaseTab
+from .tabs.docker_tab import DockerTab
 from .tabs.logs_tab import LogsTab
 from .tabs.settings_tab import SettingsTab
 
@@ -166,11 +167,17 @@ class MainWindow(QMainWindow):
         self.database_tab = DatabaseTab(self)
         self.tabs.addTab(self.database_tab, "Database")
 
+        self.docker_tab = DockerTab(self)
+        self.tabs.addTab(self.docker_tab, "Docker")
+
         self.logs_tab = LogsTab(self)
         self.tabs.addTab(self.logs_tab, "Logs")
 
         self.settings_tab = SettingsTab(self)
         self.tabs.addTab(self.settings_tab, "Settings")
+
+        # docker tab availability
+        self.docker_tab.setEnabled(self.use_docker)
 
         # populate settings widgets with loaded values
         self.project_path_edit.setText(self.project_path)

--- a/fusor/tabs/docker_tab.py
+++ b/fusor/tabs/docker_tab.py
@@ -1,0 +1,49 @@
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QPushButton, QSizePolicy
+
+
+class DockerTab(QWidget):
+    """Additional Docker helper commands."""
+
+    def __init__(self, main_window):
+        super().__init__()
+        self.main_window = main_window
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(20, 20, 20, 20)
+        layout.setSpacing(12)
+
+        self.build_btn = self._btn("🔨 Rebuild Images", self.build)
+        self.pull_btn = self._btn("⬇ Pull Images", self.pull)
+        self.status_btn = self._btn("📋 Status", self.status)
+        self.logs_btn = self._btn("📄 Logs", self.logs)
+        self.restart_btn = self._btn("🔄 Restart", self.restart)
+
+        layout.addWidget(self.build_btn)
+        layout.addWidget(self.pull_btn)
+        layout.addWidget(self.status_btn)
+        layout.addWidget(self.logs_btn)
+        layout.addWidget(self.restart_btn)
+
+        layout.addStretch(1)
+
+    def _btn(self, text, slot):
+        btn = QPushButton(text)
+        btn.setMinimumHeight(36)
+        btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        btn.clicked.connect(slot)
+        return btn
+
+    def build(self):
+        self.main_window.run_command(["docker", "compose", "build"])
+
+    def pull(self):
+        self.main_window.run_command(["docker", "compose", "pull"])
+
+    def status(self):
+        self.main_window.run_command(["docker", "compose", "ps"])
+
+    def logs(self):
+        self.main_window.run_command(["docker", "compose", "logs", "--tail", "50"])
+
+    def restart(self):
+        self.main_window.run_command(["docker", "compose", "restart"])

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -118,6 +118,8 @@ class SettingsTab(QWidget):
         self.php_path_edit.setEnabled(not checked)
         self.php_browse_btn.setEnabled(not checked)
         self.php_service_edit.setEnabled(checked)
+        if hasattr(self.main_window, "docker_tab"):
+            self.main_window.docker_tab.setEnabled(checked)
 
     def browse_project_path(self):
         directory = QFileDialog.getExistingDirectory(

--- a/tests/test_docker_tab.py
+++ b/tests/test_docker_tab.py
@@ -1,0 +1,31 @@
+from PyQt6.QtCore import Qt
+
+from fusor.tabs.docker_tab import DockerTab
+
+
+class DummyMainWindow:
+    def __init__(self):
+        self.commands = []
+
+    def run_command(self, cmd):
+        self.commands.append(cmd)
+
+
+def test_buttons_run_commands(monkeypatch, qtbot):
+    main = DummyMainWindow()
+    tab = DockerTab(main)
+    qtbot.addWidget(tab)
+
+    qtbot.mouseClick(tab.build_btn, Qt.MouseButton.LeftButton)
+    qtbot.mouseClick(tab.pull_btn, Qt.MouseButton.LeftButton)
+    qtbot.mouseClick(tab.status_btn, Qt.MouseButton.LeftButton)
+    qtbot.mouseClick(tab.logs_btn, Qt.MouseButton.LeftButton)
+    qtbot.mouseClick(tab.restart_btn, Qt.MouseButton.LeftButton)
+
+    assert main.commands == [
+        ["docker", "compose", "build"],
+        ["docker", "compose", "pull"],
+        ["docker", "compose", "ps"],
+        ["docker", "compose", "logs", "--tail", "50"],
+        ["docker", "compose", "restart"],
+    ]

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -159,12 +159,14 @@ class TestMainWindow:
         qtbot.wait(10)
         assert not main_window.php_path_edit.isEnabled()
         assert main_window.php_service_edit.isEnabled()
+        assert main_window.docker_tab.isEnabled()
 
         # disable docker again and widgets should be enabled
         main_window.docker_checkbox.setChecked(False)
         qtbot.wait(10)
         assert main_window.php_path_edit.isEnabled()
         assert not main_window.php_service_edit.isEnabled()
+        assert not main_window.docker_tab.isEnabled()
 
     def test_composer_install_button_runs_command(self, main_window, qtbot, monkeypatch):
         captured = []


### PR DESCRIPTION
## Summary
- add a new Docker tab with commands for common container tasks
- enable or disable the Docker tab based on the Docker checkbox
- update Settings tab to control Docker tab state
- document the Docker tab in the README
- test Docker tab buttons and Docker tab enabling

## Testing
- `ruff check .`
- `mypy fusor`
- `pytest -q`