### PR TITLE
Add About dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Fusor is a minimal PyQt6 application with a main window titled
 that provide helper actions for typical PHP development tasks.
 
 An **About** dialog with the project's name, author and version is available
-from the **Help** menu.
+via the **Help** button in the top-right corner.
 
 The interface now uses a dark theme defined in `fusor/main_window.py` and larger buttons for better visibility.
 The Project tab places the **Start** and **Stop** buttons side by side for

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Fusor is a minimal PyQt6 application with a main window titled
 **"Fusor – Laravel/PHP QA Toolbox"**. The UI is organized into several tabs
 that provide helper actions for typical PHP development tasks.
 
+An **About** dialog with the project's name, author and version is available
+from the **Help** menu.
+
 The interface now uses a dark theme defined in `fusor/main_window.py` and larger buttons for better visibility.
 The Project tab places the **Start** and **Stop** buttons side by side for
 quicker access, and other tabs feature taller buttons as well.

--- a/fusor/__init__.py
+++ b/fusor/__init__.py
@@ -1,0 +1,7 @@
+APP_NAME = "Fusor"
+__version__ = "0.1.0"
+DESCRIPTION = (
+    "A minimal PyQt6 application with helper tools for PHP development."
+)
+AUTHOR = "Fusor Dev"
+

--- a/fusor/about_dialog.py
+++ b/fusor/about_dialog.py
@@ -1,0 +1,26 @@
+from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel, QDialogButtonBox
+from PyQt6.QtCore import Qt
+
+from . import APP_NAME, __version__, DESCRIPTION, AUTHOR
+
+
+class AboutDialog(QDialog):
+    """Simple dialog showing project information."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle(f"About {APP_NAME}")
+        layout = QVBoxLayout(self)
+
+        title = QLabel(f"<h2>{APP_NAME}</h2>")
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(title)
+
+        layout.addWidget(QLabel(f"Version: {__version__}"))
+        layout.addWidget(QLabel(f"Author: {AUTHOR}"))
+        layout.addWidget(QLabel(DESCRIPTION))
+
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok)
+        buttons.accepted.connect(self.accept)
+        layout.addWidget(buttons, alignment=Qt.AlignmentFlag.AlignCenter)
+

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -35,6 +35,10 @@ class MainWindow(QMainWindow):
         self.setWindowTitle("Fusor – Laravel/PHP QA Toolbox")
         self.resize(1024, 768)
 
+        help_menu = self.menuBar().addMenu("Help")
+        self.about_action = help_menu.addAction("About")
+        self.about_action.triggered.connect(self.show_about_dialog)
+
         self.setStyleSheet("""
             QMainWindow {
                 background-color: #1e1e1e;
@@ -493,3 +497,9 @@ class MainWindow(QMainWindow):
             self.server_process = None
         self.executor.shutdown(wait=False)
         super().closeEvent(event)
+
+    def show_about_dialog(self):
+        from .about_dialog import AboutDialog
+
+        dlg = AboutDialog(self)
+        dlg.exec()

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -9,7 +9,9 @@ from PyQt6.QtWidgets import (
     QTabWidget,
     QWidget,
     QVBoxLayout,
+    QHBoxLayout,
     QTextEdit,
+    QPushButton,
     QMessageBox,
     QFileDialog,
     QInputDialog,
@@ -35,9 +37,6 @@ class MainWindow(QMainWindow):
         self.setWindowTitle("Fusor – Laravel/PHP QA Toolbox")
         self.resize(1024, 768)
 
-        help_menu = self.menuBar().addMenu("Help")
-        self.about_action = help_menu.addAction("About")
-        self.about_action.triggered.connect(self.show_about_dialog)
 
         self.setStyleSheet("""
             QMainWindow {
@@ -134,6 +133,13 @@ class MainWindow(QMainWindow):
 
         central_widget = QWidget()
         main_layout = QVBoxLayout(central_widget)
+
+        header_layout = QHBoxLayout()
+        header_layout.addStretch()
+        self.help_button = QPushButton("Help")
+        self.help_button.clicked.connect(self.show_about_dialog)
+        header_layout.addWidget(self.help_button)
+        main_layout.addLayout(header_layout)
 
         main_layout.addWidget(self.tabs)
 

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -247,7 +247,7 @@ class TestMainWindow:
         assert not main_window.settings_tab.log_path_row.isHidden()
         assert not main_window.settings_tab.log_path_label.isHidden()
 
-    def test_about_action_opens_dialog(self, main_window, monkeypatch):
+    def test_help_button_opens_dialog(self, main_window, qtbot, monkeypatch):
         shown = []
 
         def fake_exec(self):
@@ -259,6 +259,6 @@ class TestMainWindow:
             raising=True,
         )
 
-        main_window.about_action.trigger()
+        qtbot.mouseClick(main_window.help_button, Qt.MouseButton.LeftButton)
 
         assert shown == ["About Fusor"]

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -246,3 +246,19 @@ class TestMainWindow:
         qtbot.wait(10)
         assert not main_window.settings_tab.log_path_row.isHidden()
         assert not main_window.settings_tab.log_path_label.isHidden()
+
+    def test_about_action_opens_dialog(self, main_window, monkeypatch):
+        shown = []
+
+        def fake_exec(self):
+            shown.append(self.windowTitle())
+
+        monkeypatch.setattr(
+            "fusor.about_dialog.AboutDialog.exec",
+            fake_exec,
+            raising=True,
+        )
+
+        main_window.about_action.trigger()
+
+        assert shown == ["About Fusor"]


### PR DESCRIPTION
## Summary
- introduce an `AboutDialog` with project info
- provide `Help -> About` menu item in the main window
- test triggering the About dialog
- document the new About dialog in the README

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q -r requirements-dev.txt`
- `pytest -q`