### PR TITLE
Add remote git branch handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ the codebase easier to maintain. Each tab lives in its own file inside
 The available tabs are:
 
 -   **Project** – buttons to manage migrations and run PHPUnit tests.
--   **Git** – simple controls for common Git actions.
+-   **Git** – simple controls for common Git actions and switching between local and remote branches.
 -   **Database** – quick actions for opening and dumping a database.
 -   **Docker** – helpers for building, pulling and inspecting containers.
 -   **Logs** – shows your project's log file (Laravel only) with a refresh

--- a/fusor/config.py
+++ b/fusor/config.py
@@ -16,6 +16,7 @@ def load_config():
                 "server_port": 8000,
                 "yii_template": "basic",
                 "log_path": os.path.join("storage", "logs", "laravel.log"),
+                "git_remote": "",
                 "projects": [],
                 "current_project": "",
             }
@@ -24,6 +25,7 @@ def load_config():
         data.setdefault("server_port", 8000)
         data.setdefault("yii_template", "basic")
         data.setdefault("log_path", os.path.join("storage", "logs", "laravel.log"))
+        data.setdefault("git_remote", "")
         data.setdefault("projects", [])
         data.setdefault("current_project", "")
         if "project_path" in data and data["project_path"]:
@@ -39,6 +41,7 @@ def load_config():
             "server_port": 8000,
             "yii_template": "basic",
             "log_path": os.path.join("storage", "logs", "laravel.log"),
+            "git_remote": "",
             "projects": [],
             "current_project": "",
         }
@@ -50,6 +53,7 @@ def load_config():
             "server_port": 8000,
             "yii_template": "basic",
             "log_path": os.path.join("storage", "logs", "laravel.log"),
+            "git_remote": "",
             "projects": [],
             "current_project": "",
         }

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -158,6 +158,7 @@ class MainWindow(QMainWindow):
         self.use_docker = False
         self.yii_template = "basic"
         self.log_path = os.path.join("storage", "logs", "laravel.log")
+        self.git_remote = ""
         self.load_config()
 
         # initialize tabs
@@ -190,6 +191,7 @@ class MainWindow(QMainWindow):
 
         if self.project_path:
             self.git_tab.load_branches()
+            self.git_tab.load_remote_branches()
         else:
             QTimer.singleShot(0, self.choose_project)
 
@@ -208,6 +210,7 @@ class MainWindow(QMainWindow):
         self.use_docker = data.get("use_docker", self.use_docker)
         self.yii_template = data.get("yii_template", self.yii_template)
         self.log_path = data.get("log_path", self.log_path)
+        self.git_remote = data.get("git_remote", self.git_remote)
 
     def run_command(self, command):
         if self.use_docker and not (
@@ -257,6 +260,7 @@ class MainWindow(QMainWindow):
             self.project_combo.blockSignals(False)
         if hasattr(self, "git_tab"):
             self.git_tab.load_branches()
+            self.git_tab.load_remote_branches()
 
     def add_project(self):
         path = QFileDialog.getExistingDirectory(self, "Select Project Path")
@@ -313,6 +317,7 @@ class MainWindow(QMainWindow):
         use_docker = self.docker_checkbox.isChecked()
         yii_template = self.yii_template_combo.currentText() if hasattr(self, "yii_template_combo") else self.yii_template
         log_path = self.log_path_edit.text() if hasattr(self, "log_path_edit") else self.log_path
+        git_remote = self.remote_combo.currentText() if hasattr(self, "remote_combo") else self.git_remote
 
         if (
             not project_path
@@ -346,6 +351,7 @@ class MainWindow(QMainWindow):
         self.use_docker = use_docker
         self.yii_template = yii_template
         self.log_path = log_path
+        self.git_remote = git_remote
 
         data = {
             "projects": self.projects,
@@ -358,6 +364,7 @@ class MainWindow(QMainWindow):
             "use_docker": use_docker,
             "yii_template": yii_template,
             "log_path": log_path,
+            "git_remote": git_remote,
         }
         try:
             save_config(data)
@@ -368,6 +375,7 @@ class MainWindow(QMainWindow):
 
         if hasattr(self, "git_tab"):
             self.git_tab.load_branches()
+            self.git_tab.load_remote_branches()
 
     def artisan(self, *args):
         self.ensure_project_path()

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -56,6 +56,14 @@ class SettingsTab(QWidget):
         self.server_port_edit = QLineEdit(str(self.main_window.server_port))
         form.addRow("Server Port:", self.server_port_edit)
 
+        self.remote_combo = QComboBox()
+        remotes = self.main_window.git_tab.get_remotes()
+        if remotes:
+            self.remote_combo.addItems(remotes)
+        if self.main_window.git_remote in remotes:
+            self.remote_combo.setCurrentText(self.main_window.git_remote)
+        form.addRow("Git Remote:", self.remote_combo)
+
         self.log_path_edit = QLineEdit(self.main_window.log_path)
         log_browse_btn = QPushButton("Browse")
         log_browse_btn.setFixedHeight(30)
@@ -103,6 +111,7 @@ class SettingsTab(QWidget):
         self.main_window.docker_checkbox = self.docker_checkbox
         self.main_window.yii_template_combo = self.yii_template_combo
         self.main_window.log_path_edit = self.log_path_edit
+        self.main_window.remote_combo = self.remote_combo
 
         self.on_docker_toggled(self.docker_checkbox.isChecked())
         self.on_framework_changed(self.framework_combo.currentText())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ def test_save_then_load(tmp_path, monkeypatch):
         "log_path": "/tmp/app.log",
         "projects": ["/one", "/two"],
         "current_project": "/two",
+        "git_remote": "origin",
     }
     config.save_config(data)
     loaded = config.load_config()
@@ -29,6 +30,7 @@ def test_load_missing_file(tmp_path, monkeypatch):
         "log_path": "storage/logs/laravel.log",
         "projects": [],
         "current_project": "",
+        "git_remote": "",
     }
 
 def test_load_invalid_json(tmp_path, monkeypatch):
@@ -43,4 +45,5 @@ def test_load_invalid_json(tmp_path, monkeypatch):
         "log_path": "storage/logs/laravel.log",
         "projects": [],
         "current_project": "",
+        "git_remote": "",
     }


### PR DESCRIPTION
## Summary
- support choosing remote branches in Git tab
- add refresh button for remote branch list
- store default git remote in config
- expose remote selector in Settings
- test new remote helpers

## Testing
- `ruff check .`
- `mypy fusor`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68750a339a5483228e7e08139580809b