### PR TITLE
Add framework tab for artisan commands

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -24,6 +24,7 @@ from .qtextedit_logger import QTextEditLogger
 from .tabs.project_tab import ProjectTab
 from .tabs.git_tab import GitTab
 from .tabs.database_tab import DatabaseTab
+from .tabs.framework_tab import FrameworkTab
 from .tabs.docker_tab import DockerTab
 from .tabs.logs_tab import LogsTab
 from .tabs.settings_tab import SettingsTab
@@ -187,6 +188,9 @@ class MainWindow(QMainWindow):
         self.database_tab = DatabaseTab(self)
         self.tabs.addTab(self.database_tab, "Database")
 
+        self.framework_tab = FrameworkTab(self)
+        self.framework_index = self.tabs.addTab(self.framework_tab, "Framework")
+
         self.docker_tab = DockerTab(self)
         self.docker_index = self.tabs.addTab(self.docker_tab, "Docker")
 
@@ -200,6 +204,11 @@ class MainWindow(QMainWindow):
         # docker tab availability
         self.tabs.setTabVisible(self.docker_index, self.use_docker)
         self.tabs.setTabEnabled(self.docker_index, self.use_docker)
+
+        # framework tab availability
+        show_fw = self.framework_choice != "None"
+        self.tabs.setTabVisible(self.framework_index, show_fw)
+        self.tabs.setTabEnabled(self.framework_index, show_fw)
 
         # populate settings widgets with loaded values
         if hasattr(self, "project_combo"):

--- a/fusor/tabs/database_tab.py
+++ b/fusor/tabs/database_tab.py
@@ -31,40 +31,11 @@ class DatabaseTab(QWidget):
         tools_group.setLayout(tools_layout)
         outer_layout.addWidget(tools_group)
 
-        # --- Migrations Group ---
-        self.migrate_group = QGroupBox("Laravel Migrations")
-        migrate_layout = QVBoxLayout()
-        migrate_layout.setSpacing(10)
-
-        migrate_layout.addWidget(self._btn("Migrate", self.main_window.migrate))
-        migrate_layout.addWidget(self._btn("↩ Rollback", self.main_window.rollback))
-        migrate_layout.addWidget(self._btn("Fresh", self.main_window.fresh))
-        migrate_layout.addWidget(self._btn("Seed", self.main_window.seed))
-
-        self.migrate_group.setLayout(migrate_layout)
-        outer_layout.addWidget(self.migrate_group)
-
-        # --- Artisan Commands ---
-        self.artisan_group = QGroupBox("Laravel Artisan")
-        artisan_layout = QVBoxLayout()
-        artisan_layout.setSpacing(10)
-
-        self.optimize_btn = self._btn(
-            "Optimize", lambda: self.main_window.artisan("optimize")
-        )
-        self.config_clear_btn = self._btn(
-            "Config Clear", lambda: self.main_window.artisan("config:clear")
-        )
-
-        artisan_layout.addWidget(self.optimize_btn)
-        artisan_layout.addWidget(self.config_clear_btn)
-
-        self.artisan_group.setLayout(artisan_layout)
-        outer_layout.addWidget(self.artisan_group)
-
         outer_layout.addStretch(1)
 
-        self.on_framework_changed(self.main_window.framework_choice)
+    def on_framework_changed(self, _text: str):
+        """Database tab has no framework specific controls."""
+        pass
 
     def _btn(self, text, slot):
         btn = QPushButton(text)
@@ -86,7 +57,3 @@ class DatabaseTab(QWidget):
         if path:
             self.main_window.run_command(["mysql", path])
 
-    def on_framework_changed(self, text: str):
-        visible = text == "Laravel"
-        self.migrate_group.setVisible(visible)
-        self.artisan_group.setVisible(visible)

--- a/fusor/tabs/framework_tab.py
+++ b/fusor/tabs/framework_tab.py
@@ -1,0 +1,59 @@
+from PyQt6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QPushButton,
+    QSizePolicy,
+    QGroupBox,
+)
+
+
+class FrameworkTab(QWidget):
+    def __init__(self, main_window):
+        super().__init__()
+        self.main_window = main_window
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(20, 20, 20, 20)
+        layout.setSpacing(20)
+
+        # --- Laravel Migrations ---
+        self.migrate_group = QGroupBox("Laravel Migrations")
+        migrate_layout = QVBoxLayout()
+        migrate_layout.setSpacing(10)
+        migrate_layout.addWidget(self._btn("Migrate", self.main_window.migrate))
+        migrate_layout.addWidget(self._btn("↩ Rollback", self.main_window.rollback))
+        migrate_layout.addWidget(self._btn("Fresh", self.main_window.fresh))
+        migrate_layout.addWidget(self._btn("Seed", self.main_window.seed))
+        self.migrate_group.setLayout(migrate_layout)
+        layout.addWidget(self.migrate_group)
+
+        # --- Laravel Artisan Commands ---
+        self.artisan_group = QGroupBox("Laravel Artisan")
+        artisan_layout = QVBoxLayout()
+        artisan_layout.setSpacing(10)
+        self.optimize_btn = self._btn(
+            "Optimize", lambda: self.main_window.artisan("optimize")
+        )
+        self.config_clear_btn = self._btn(
+            "Config Clear", lambda: self.main_window.artisan("config:clear")
+        )
+        artisan_layout.addWidget(self.optimize_btn)
+        artisan_layout.addWidget(self.config_clear_btn)
+        self.artisan_group.setLayout(artisan_layout)
+        layout.addWidget(self.artisan_group)
+
+        layout.addStretch(1)
+
+        self.on_framework_changed(self.main_window.framework_choice)
+
+    def _btn(self, text, slot):
+        btn = QPushButton(text)
+        btn.setMinimumHeight(36)
+        btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        btn.clicked.connect(slot)
+        return btn
+
+    def on_framework_changed(self, text: str):
+        visible = text == "Laravel"
+        self.migrate_group.setVisible(visible)
+        self.artisan_group.setVisible(visible)
+

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -89,6 +89,10 @@ class SettingsTab(QWidget):
         self.framework_combo.currentTextChanged.connect(
             self.main_window.database_tab.on_framework_changed
         )
+        if hasattr(self.main_window, "framework_tab"):
+            self.framework_combo.currentTextChanged.connect(
+                self.main_window.framework_tab.on_framework_changed
+            )
         form.addRow("Framework:", self.framework_combo)
 
         self.log_path_edit = QLineEdit(self.main_window.log_path)
@@ -140,6 +144,8 @@ class SettingsTab(QWidget):
         current_fw = self.framework_combo.currentText()
         self.on_framework_changed(current_fw)
         self.main_window.database_tab.on_framework_changed(current_fw)
+        if hasattr(self.main_window, "framework_tab"):
+            self.main_window.framework_tab.on_framework_changed(current_fw)
 
         # track unsaved changes
         self.project_combo.currentTextChanged.connect(self.main_window.mark_settings_dirty)
@@ -242,4 +248,10 @@ class SettingsTab(QWidget):
         self.log_path_label.setVisible(log_visible)
         if hasattr(self.main_window, "database_tab"):
             self.main_window.database_tab.on_framework_changed(text)
+        if hasattr(self.main_window, "framework_tab"):
+            self.main_window.framework_tab.on_framework_changed(text)
+        if hasattr(self.main_window, "framework_index"):
+            show_fw = text != "None"
+            self.main_window.tabs.setTabVisible(self.main_window.framework_index, show_fw)
+            self.main_window.tabs.setTabEnabled(self.main_window.framework_index, show_fw)
 

--- a/tests/test_database_tab.py
+++ b/tests/test_database_tab.py
@@ -6,18 +6,13 @@ from fusor.tabs.database_tab import DatabaseTab
 class DummyMainWindow:
     def __init__(self):
         self.commands = []
-        # stubs used by migration buttons but not tested here
-        self.migrate = lambda: None
-        self.rollback = lambda: None
-        self.fresh = lambda: None
-        self.seed = lambda: None
         self.framework_choice = "Laravel"
+
+    # stubs used by buttons but not tested here
+    migrate = rollback = fresh = seed = lambda self: None
 
     def run_command(self, cmd):
         self.commands.append(cmd)
-
-    def artisan(self, *args):
-        self.commands.append(list(args))
 
 
 def test_dbeaver_button_runs_command(monkeypatch, qtbot):
@@ -62,35 +57,3 @@ def test_restore_button_runs_command(monkeypatch, qtbot):
     assert main.commands == [["mysql", "/tmp/d.sql"]]
 
 
-def test_optimize_button_runs_command(qtbot):
-    main = DummyMainWindow()
-    tab = DatabaseTab(main)
-    qtbot.addWidget(tab)
-
-    qtbot.mouseClick(tab.optimize_btn, Qt.MouseButton.LeftButton)
-
-    assert main.commands == [["optimize"]]
-
-
-def test_config_clear_button_runs_command(qtbot):
-    main = DummyMainWindow()
-    tab = DatabaseTab(main)
-    qtbot.addWidget(tab)
-
-    qtbot.mouseClick(tab.config_clear_btn, Qt.MouseButton.LeftButton)
-
-    assert main.commands == [["config:clear"]]
-
-
-def test_artisan_group_visibility_changes(qtbot):
-    main = DummyMainWindow()
-    tab = DatabaseTab(main)
-    qtbot.addWidget(tab)
-
-    tab.on_framework_changed("None")
-    assert tab.artisan_group.isHidden()
-    assert tab.migrate_group.isHidden()
-
-    tab.on_framework_changed("Laravel")
-    assert not tab.artisan_group.isHidden()
-    assert not tab.migrate_group.isHidden()

--- a/tests/test_framework_tab.py
+++ b/tests/test_framework_tab.py
@@ -1,0 +1,44 @@
+from PyQt6.QtCore import Qt
+
+from fusor.tabs.framework_tab import FrameworkTab
+
+
+class DummyMainWindow:
+    def __init__(self):
+        self.commands = []
+        self.migrate = lambda: self.artisan("migrate")
+        self.rollback = lambda: self.artisan("migrate:rollback")
+        self.fresh = lambda: self.artisan("migrate:fresh")
+        self.seed = lambda: self.artisan("db:seed")
+        self.framework_choice = "Laravel"
+
+    def run_command(self, cmd):
+        self.commands.append(cmd)
+
+    def artisan(self, *args):
+        self.commands.append(list(args))
+
+
+def test_artisan_buttons_run_commands(qtbot):
+    main = DummyMainWindow()
+    tab = FrameworkTab(main)
+    qtbot.addWidget(tab)
+
+    qtbot.mouseClick(tab.optimize_btn, Qt.MouseButton.LeftButton)
+    qtbot.mouseClick(tab.config_clear_btn, Qt.MouseButton.LeftButton)
+
+    assert main.commands == [["optimize"], ["config:clear"]]
+
+
+def test_visibility_changes(qtbot):
+    main = DummyMainWindow()
+    tab = FrameworkTab(main)
+    qtbot.addWidget(tab)
+
+    tab.on_framework_changed("None")
+    assert tab.artisan_group.isHidden()
+    assert tab.migrate_group.isHidden()
+
+    tab.on_framework_changed("Laravel")
+    assert not tab.artisan_group.isHidden()
+    assert not tab.migrate_group.isHidden()

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -233,6 +233,20 @@ class TestMainWindow:
         assert not main_window.tabs.isTabVisible(main_window.docker_index)
         assert not main_window.tabs.isTabEnabled(main_window.docker_index)
 
+    def test_framework_tab_visibility(self, main_window, qtbot):
+        assert main_window.tabs.isTabVisible(main_window.framework_index)
+        assert main_window.tabs.isTabEnabled(main_window.framework_index)
+
+        main_window.framework_combo.setCurrentText("None")
+        qtbot.wait(10)
+        assert not main_window.tabs.isTabVisible(main_window.framework_index)
+        assert not main_window.tabs.isTabEnabled(main_window.framework_index)
+
+        main_window.framework_combo.setCurrentText("Laravel")
+        qtbot.wait(10)
+        assert main_window.tabs.isTabVisible(main_window.framework_index)
+        assert main_window.tabs.isTabEnabled(main_window.framework_index)
+
     def test_composer_install_button_runs_command(self, main_window, qtbot, monkeypatch):
         captured = []
         monkeypatch.setattr(main_window, "run_command", lambda cmd: captured.append(cmd), raising=True)


### PR DESCRIPTION
## Summary
- move Laravel-specific migrations and artisan actions from Database tab to a new **Framework** tab
- hide/show the Framework tab based on selected framework
- update settings handling and tests

## Testing
- `pytest -q`