### PR TITLE
Add Create Branch UI

### DIFF
--- a/fusor/tabs/git_tab.py
+++ b/fusor/tabs/git_tab.py
@@ -1,6 +1,14 @@
 from PyQt6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QPushButton,
-    QComboBox, QSizePolicy, QMessageBox, QGroupBox, QLabel
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QPushButton,
+    QComboBox,
+    QSizePolicy,
+    QMessageBox,
+    QGroupBox,
+    QLabel,
+    QLineEdit,
 )
 
 import subprocess
@@ -39,6 +47,16 @@ class GitTab(QWidget):
         remote_layout.addWidget(refresh_btn)
         remote_group.setLayout(remote_layout)
         outer_layout.addWidget(remote_group)
+
+        # --- Create branch ---
+        create_group = QGroupBox("Create Branch")
+        create_layout = QHBoxLayout()
+        self.branch_name_edit = QLineEdit()
+        create_btn = self._btn("Create Branch", self.create_branch)
+        create_layout.addWidget(self.branch_name_edit)
+        create_layout.addWidget(create_btn)
+        create_group.setLayout(create_layout)
+        outer_layout.addWidget(create_group)
 
         # --- Git actions ---
         actions_group = QGroupBox("Git Commands")
@@ -162,6 +180,14 @@ class GitTab(QWidget):
             print("Changes stashed successfully")
         else:
             print("Stash failed")
+
+    def create_branch(self):
+        branch = self.branch_name_edit.text().strip()
+        if not branch:
+            return
+        self.run_git_command("checkout", "-b", branch)
+        self.load_branches()
+        self.branch_combo.setCurrentText(branch)
 
     def get_remotes(self) -> list[str]:
         if not self.main_window.project_path:

--- a/tests/test_git_tab.py
+++ b/tests/test_git_tab.py
@@ -162,3 +162,28 @@ def test_push_button_runs_push(monkeypatch, qtbot):
     qtbot.mouseClick(push_btn, Qt.MouseButton.LeftButton)
 
     assert called["args"] == ("push",)
+
+
+def test_create_branch_button(monkeypatch, qtbot):
+    main = DummyMainWindow()
+    tab = GitTab(main)
+    qtbot.addWidget(tab)
+
+    called = {}
+
+    def fake_run_git_command(*args):
+        called["args"] = args
+
+    monkeypatch.setattr(tab, "run_git_command", fake_run_git_command, raising=True)
+
+    create_btn: QPushButton | None = None
+    for btn in tab.findChildren(QPushButton):
+        if btn.text() == "Create Branch":
+            create_btn = btn
+            break
+    assert create_btn is not None
+
+    tab.branch_name_edit.setText("feature")
+    qtbot.mouseClick(create_btn, Qt.MouseButton.LeftButton)
+
+    assert called["args"] == ("checkout", "-b", "feature")


### PR DESCRIPTION
## Summary
- add `QLineEdit` and button to create git branches
- run `git checkout -b` when the button is triggered
- test create branch button

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68757b27cce48322b92533d72ec67924