### PR TITLE
Add Git log view button

### DIFF
--- a/fusor/tabs/git_tab.py
+++ b/fusor/tabs/git_tab.py
@@ -67,11 +67,13 @@ class GitTab(QWidget):
         push_btn = self._btn("⬆ Push", lambda: self.run_git_command("push"))
         reset_btn = self._btn("↩ Hard Reset", self.hard_reset)
         stash_btn = self._btn("💾 Stash", self.stash)
+        view_log_btn = self._btn("📜 View Log", self.view_log)
 
         actions_layout.addWidget(pull_btn)
         actions_layout.addWidget(push_btn)
         actions_layout.addWidget(reset_btn)
         actions_layout.addWidget(stash_btn)
+        actions_layout.addWidget(view_log_btn)
 
         actions_group.setLayout(actions_layout)
         outer_layout.addWidget(actions_group)
@@ -180,6 +182,10 @@ class GitTab(QWidget):
             print("Changes stashed successfully")
         else:
             print("Stash failed")
+
+    def view_log(self):
+        """Show recent git log entries."""
+        self.run_git_command("log", "-n", "20", "--oneline")
 
     def create_branch(self):
         branch = self.branch_name_edit.text().strip()

--- a/tests/test_git_tab.py
+++ b/tests/test_git_tab.py
@@ -187,3 +187,27 @@ def test_create_branch_button(monkeypatch, qtbot):
     qtbot.mouseClick(create_btn, Qt.MouseButton.LeftButton)
 
     assert called["args"] == ("checkout", "-b", "feature")
+
+
+def test_view_log_button_runs_log(monkeypatch, qtbot):
+    main = DummyMainWindow()
+    tab = GitTab(main)
+    qtbot.addWidget(tab)
+
+    called = {}
+
+    def fake_run_git_command(*args):
+        called["args"] = args
+
+    monkeypatch.setattr(tab, "run_git_command", fake_run_git_command, raising=True)
+
+    view_btn: QPushButton | None = None
+    for btn in tab.findChildren(QPushButton):
+        if btn.text() == "📜 View Log":
+            view_btn = btn
+            break
+    assert view_btn is not None
+
+    qtbot.mouseClick(view_btn, Qt.MouseButton.LeftButton)
+
+    assert called["args"] == ("log", "-n", "20", "--oneline")


### PR DESCRIPTION
## Summary
- add a *View Log* button to `GitTab`
- implement `view_log` handler to run `git log -n 20 --oneline`
- test that the new button triggers the command

## Testing
- `pytest -q`