### PR TITLE
Fix duplicate QTextEdit initialization

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -140,8 +140,6 @@ class MainWindow(QMainWindow):
         """)
 
         self.tabs = QTabWidget()
-        self.output_view = QTextEdit()
-        self.output_view.setReadOnly(True)
 
         central_widget = QWidget()
         main_layout = QVBoxLayout(central_widget)


### PR DESCRIPTION
## Summary
- remove redundant construction of `output_view` in `MainWindow`
- keep read-only settings on the remaining instance

## Testing
- `pytest -q`