### PR TITLE
Lazy load Git remote branches

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -194,7 +194,7 @@ class MainWindow(QMainWindow):
         self.tabs.addTab(self.project_tab, "Project")
 
         self.git_tab = GitTab(self)
-        self.tabs.addTab(self.git_tab, "Git")
+        self.git_index = self.tabs.addTab(self.git_tab, "Git")
 
         self.database_tab = DatabaseTab(self)
         self.tabs.addTab(self.database_tab, "Database")
@@ -229,7 +229,6 @@ class MainWindow(QMainWindow):
 
         if self.project_path:
             self.git_tab.load_branches()
-            self.git_tab.load_remote_branches()
         else:
             QTimer.singleShot(0, self.choose_project)
 
@@ -248,6 +247,8 @@ class MainWindow(QMainWindow):
             and all(isinstance(i, int) for i in self._geom_pos)
         ):
             self.move(*self._geom_pos)
+
+        self.tabs.currentChanged.connect(self.on_tab_changed)
 
     def load_config(self):
         data = load_config()
@@ -405,8 +406,8 @@ class MainWindow(QMainWindow):
             self.project_combo.setCurrentText(path)
             self.project_combo.blockSignals(False)
         if hasattr(self, "git_tab"):
+            self.git_tab.remote_branches_loaded = False
             self.git_tab.load_branches()
-            self.git_tab.load_remote_branches()
 
         self.apply_project_settings()
 
@@ -563,8 +564,8 @@ class MainWindow(QMainWindow):
             self.logs_tab.update_timer_interval(self.auto_refresh_secs)
 
         if hasattr(self, "git_tab"):
+            self.git_tab.remote_branches_loaded = False
             self.git_tab.load_branches()
-            self.git_tab.load_remote_branches()
 
     def artisan(self, *args):
         self.ensure_project_path()
@@ -702,6 +703,11 @@ class MainWindow(QMainWindow):
 
         dlg = AboutDialog(self)
         dlg.exec()
+
+    def on_tab_changed(self, index: int):
+        if index == getattr(self, "git_index", -1):
+            if not self.git_tab.remote_branches_loaded:
+                self.git_tab.load_remote_branches()
 
     def clear_output(self):
         self.output_view.clear()

--- a/fusor/tabs/git_tab.py
+++ b/fusor/tabs/git_tab.py
@@ -18,6 +18,7 @@ class GitTab(QWidget):
         super().__init__()
         self.main_window = main_window
         self.current_branch = ""
+        self.remote_branches_loaded = False
 
         outer_layout = QVBoxLayout(self)
         outer_layout.setContentsMargins(20, 20, 20, 20)
@@ -233,6 +234,7 @@ class GitTab(QWidget):
             print("Command not found: git")
         finally:
             self.remote_branch_combo.blockSignals(False)
+            self.remote_branches_loaded = True
 
     def checkout_remote_branch(self, branch: str):
         remote = self.main_window.git_remote

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -8,7 +8,8 @@ from PyQt6.QtCore import QTimer, Qt
 
 import fusor.main_window as mw_module
 from fusor.main_window import MainWindow
-from PyQt6.QtWidgets import QMainWindow
+from PyQt6.QtWidgets import QMainWindow, QPushButton
+from fusor.tabs.git_tab import GitTab
 
 # ---------------------------------------------------------------------------
 # Helpers & fixtures
@@ -642,3 +643,68 @@ class TestMainWindow:
 
         assert saved["window_size"] == [777, 555]
         assert saved["window_position"] == [11, 22]
+
+    def test_git_tab_loads_remote_on_first_show(self, qtbot, monkeypatch):
+        monkeypatch.setattr(QTimer, "singleShot", lambda *a, **k: None, raising=True)
+        monkeypatch.setattr(mw_module, "load_config", lambda: {}, raising=True)
+        monkeypatch.setattr(mw_module, "save_config", lambda *a, **k: None, raising=True)
+
+        calls = []
+
+        def fake(self):
+            calls.append(True)
+            self.remote_branches_loaded = True
+
+        monkeypatch.setattr(GitTab, "load_remote_branches", fake, raising=True)
+
+        win = MainWindow()
+        qtbot.addWidget(win)
+        win.show()
+
+        assert not win.git_tab.remote_branches_loaded
+
+        win.tabs.setCurrentIndex(win.git_index)
+        qtbot.wait(10)
+
+        assert calls == [True]
+
+        win.tabs.setCurrentIndex(win.settings_index)
+        qtbot.wait(10)
+        win.tabs.setCurrentIndex(win.git_index)
+        qtbot.wait(10)
+
+        assert calls == [True]
+        win.close()
+
+    def test_git_refresh_button_triggers_load(self, qtbot, monkeypatch):
+        monkeypatch.setattr(QTimer, "singleShot", lambda *a, **k: None, raising=True)
+        monkeypatch.setattr(mw_module, "load_config", lambda: {}, raising=True)
+        monkeypatch.setattr(mw_module, "save_config", lambda *a, **k: None, raising=True)
+
+        calls = []
+
+        def fake(self):
+            calls.append(True)
+            self.remote_branches_loaded = True
+
+        monkeypatch.setattr(GitTab, "load_remote_branches", fake, raising=True)
+
+        win = MainWindow()
+        qtbot.addWidget(win)
+        win.show()
+
+        win.tabs.setCurrentIndex(win.git_index)
+        qtbot.wait(10)
+
+        refresh_btn = None
+        for btn in win.git_tab.findChildren(QPushButton):
+            if btn.text() == "🔄 Refresh":
+                refresh_btn = btn
+                break
+        assert refresh_btn is not None
+
+        qtbot.mouseClick(refresh_btn, Qt.MouseButton.LeftButton)
+        qtbot.wait(10)
+
+        assert calls == [True, True]
+        win.close()


### PR DESCRIPTION
## Summary
- load Git remote branches only when the Git tab becomes visible
- track whether remote branches were loaded
- update project switching and settings saving to reset the loaded flag
- test lazy loading and refresh button functionality

## Testing
- `pytest -q`