### PR TITLE
Improve log refresh performance

### DIFF
--- a/fusor/config.py
+++ b/fusor/config.py
@@ -16,6 +16,7 @@ DEFAULT_PROJECT_SETTINGS = {
     "git_remote": "",
     "compose_files": [],
     "auto_refresh_secs": 5,
+    "max_log_lines": 1000,
 }
 
 # Default configuration values

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -33,6 +33,9 @@ from .tabs.settings_tab import SettingsTab
 # allow tests to monkeypatch file operations easily
 open = builtins.open
 
+# Number of log lines to read from the end of a log file
+MAX_LOG_LINES = 1000
+
 class MainWindow(QMainWindow):
     def __init__(self):
         super().__init__()
@@ -186,6 +189,7 @@ class MainWindow(QMainWindow):
         self.yii_template = "basic"
         self.log_path = os.path.join("storage", "logs", "laravel.log")
         self.git_remote = ""
+        self.max_log_lines = MAX_LOG_LINES
         self.auto_refresh_secs = 5
         self.load_config()
 
@@ -287,6 +291,10 @@ class MainWindow(QMainWindow):
             "auto_refresh_secs",
             data.get("auto_refresh_secs", self.auto_refresh_secs),
         )
+        self.max_log_lines = settings.get(
+            "max_log_lines",
+            data.get("max_log_lines", self.max_log_lines),
+        )
 
         self._geom_size = data.get("window_size")
         self._geom_pos = data.get("window_position")
@@ -328,6 +336,7 @@ class MainWindow(QMainWindow):
         self.git_remote = settings["git_remote"]
         self.compose_files = settings["compose_files"]
         self.auto_refresh_secs = settings["auto_refresh_secs"]
+        self.max_log_lines = settings.get("max_log_lines", self.max_log_lines)
 
         if hasattr(self, "framework_combo"):
             self.framework_combo.setCurrentText(self.framework_choice)
@@ -433,6 +442,27 @@ class MainWindow(QMainWindow):
     def current_framework(self):
         return self.framework_combo.currentText() if hasattr(self, "framework_combo") else "None"
 
+    def _tail_file(self, path: str, lines: int) -> str:
+        """Return the last ``lines`` lines from ``path``."""
+        try:
+            with open(path, "rb") as f:
+                f.seek(0, os.SEEK_END)
+                remaining = f.tell()
+                block_size = 4096
+                data = b""
+                line_count = 0
+                while remaining > 0 and line_count <= lines:
+                    read_size = block_size if remaining >= block_size else remaining
+                    remaining -= read_size
+                    f.seek(remaining)
+                    chunk = f.read(read_size)
+                    data = chunk + data
+                    line_count = data.count(b"\n")
+                lines_data = data.splitlines()[-lines:]
+                return "\n".join(line.decode("utf-8", "replace") for line in lines_data)
+        except OSError as e:
+            return f"Failed to read log file: {e}"
+
     def refresh_logs(self):
         if not self.ensure_project_path():
             return
@@ -444,11 +474,7 @@ class MainWindow(QMainWindow):
             if not os.path.isabs(log_file):
                 log_file = os.path.join(self.project_path, log_file)
             if os.path.exists(log_file):
-                try:
-                    with open(log_file, "r", encoding="utf-8") as f:
-                        log_contents = f.read()
-                except OSError as e:
-                    log_contents = f"Failed to read log file: {e}"
+                log_contents = self._tail_file(log_file, self.max_log_lines)
             else:
                 log_contents = f"Log file not found: {log_file}"
         elif framework == "Yii":
@@ -465,11 +491,7 @@ class MainWindow(QMainWindow):
             parts: list[str] = []
             for file in log_files:
                 if os.path.exists(file):
-                    try:
-                        with open(file, "r", encoding="utf-8") as f:
-                            content = f.read()
-                    except OSError as e:
-                        content = f"Failed to read log file: {e}"
+                    content = self._tail_file(file, self.max_log_lines)
                 else:
                     content = f"Log file not found: {file}"
                 parts.append(content)
@@ -531,6 +553,7 @@ class MainWindow(QMainWindow):
         self.git_remote = git_remote
         self.compose_files = [f for f in compose_text.split(";") if f]
         self.auto_refresh_secs = int(auto_refresh_secs)
+        self.max_log_lines = int(getattr(self, "max_log_lines", MAX_LOG_LINES))
 
         data = load_config()
         settings = data.get("project_settings", {})
@@ -545,6 +568,7 @@ class MainWindow(QMainWindow):
             "git_remote": git_remote,
             "compose_files": self.compose_files,
             "auto_refresh_secs": self.auto_refresh_secs,
+            "max_log_lines": self.max_log_lines,
         }
         data.update({
             "projects": self.projects,

--- a/tests/test_logs_tab.py
+++ b/tests/test_logs_tab.py
@@ -72,3 +72,29 @@ def test_search_cycle_multiple_matches(qtbot):
     qtbot.wait(10)
     assert current_start() == 16
 
+def test_auto_refresh_truncates_large_file(tmp_path, qtbot, monkeypatch):
+    from PyQt6.QtCore import QTimer
+    from fusor import main_window as mw_module
+    from fusor.main_window import MainWindow
+
+    monkeypatch.setattr(QTimer, "singleShot", lambda *a, **k: None, raising=True)
+    monkeypatch.setattr(mw_module, "load_config", lambda: {}, raising=True)
+    monkeypatch.setattr(mw_module, "save_config", lambda *a, **k: None, raising=True)
+
+    win = MainWindow()
+    qtbot.addWidget(win)
+    win.show()
+
+    win.project_path = str(tmp_path)
+    win.log_path = "big.log"
+    win.max_log_lines = 1000
+
+    lines = [f"line {i}" for i in range(2000)]
+    (tmp_path / "big.log").write_text("\n".join(lines))
+
+    win.logs_tab.auto_checkbox.setChecked(True)
+    qtbot.wait(10)
+
+    result = win.log_view.toPlainText().splitlines()
+    assert result == lines[-1000:]
+

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -421,6 +421,20 @@ class TestMainWindow:
         for part in ["frontend", "backend", "console"]:
             assert f"{part} log" in main_window.log_view.text
 
+    def test_refresh_logs_truncates_large_files(self, tmp_path: Path, main_window):
+        log_file = tmp_path / "large.log"
+        lines = [f"line {i}" for i in range(2000)]
+        log_file.write_text("\n".join(lines))
+        main_window.project_path = str(tmp_path)
+        main_window.log_view = FakeLogView()
+        main_window.log_path = "large.log"
+        main_window.max_log_lines = 1000
+
+        main_window.refresh_logs()
+
+        result = main_window.log_view.text.splitlines()
+        assert result == lines[-1000:]
+
     def test_yii_template_row_visibility(self, main_window, qtbot):
         main_window.framework_combo.setCurrentText("None")
         qtbot.wait(10)


### PR DESCRIPTION
## Summary
- tail log files instead of reading them whole
- store maximum log lines in config
- test truncation behavior in MainWindow
- test truncation behavior via LogsTab

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876100a27348322a65e8a0351884a7a