### PR TITLE
Add theme selector and styling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An **About** dialog with the project's name, author and version is available
 via the **Help** button in the top-right corner.
 
 The interface now uses a dark theme defined in `fusor/main_window.py` and larger buttons for better visibility.
+A "Theme" selector in the Settings tab lets you switch between Dark and Light modes.
 The Project tab places the **Start** and **Stop** buttons side by side for
 quicker access, and other tabs feature taller buttons as well.
 

--- a/fusor/config.py
+++ b/fusor/config.py
@@ -23,6 +23,7 @@ DEFAULT_CONFIG = {
     "projects": [],
     "current_project": "",
     "project_settings": {},
+    "theme": "dark",
     # Window geometry (width, height) and position (x, y)
     "window_size": [1024, 768],
     "window_position": [100, 100],

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -33,114 +33,217 @@ from .tabs.settings_tab import SettingsTab
 # allow tests to monkeypatch file operations easily
 open = builtins.open
 
+DARK_STYLESHEET = """
+    QMainWindow {
+        background-color: #1e1e1e;
+    }
+
+    QTabWidget::pane {
+        border: none;
+    }
+
+    QWidget {
+        background-color: #1e1e1e;
+        color: #dddddd;
+        font-family: "Segoe UI", "Arial", sans-serif;
+        font-size: 14px;
+    }
+
+    QPushButton {
+        background-color: #2e7d32;
+        color: #ffffff;
+        padding: 8px 16px;
+        border: none;
+        border-radius: 6px;
+        font-weight: 500;
+    }
+
+    QPushButton:hover {
+        background-color: #388e3c;
+    }
+
+    QPushButton:pressed {
+        background-color: #1b5e20;
+    }
+
+    QPushButton:disabled {
+        background-color: #555555;
+        color: #999999;
+    }
+
+    QTextEdit, QLineEdit {
+        background-color: #2c2c2c;
+        color: #eeeeee;
+        padding: 8px;
+        border: 1px solid #444444;
+        border-radius: 6px;
+        font-family: monospace;
+    }
+
+    QTextEdit:disabled, QLineEdit:disabled, QComboBox:disabled {
+        background-color: #3a3a3a;
+        color: #777777;
+    }
+
+    QComboBox {
+        background-color: #2c2c2c;
+        color: #eeeeee;
+        padding: 6px;
+        border: 1px solid #444444;
+        border-radius: 6px;
+    }
+
+    QComboBox QAbstractItemView {
+        background-color: #2c2c2c;
+        selection-background-color: #388e3c;
+        selection-color: white;
+    }
+
+    QTabBar::tab {
+        background: transparent;
+        color: #888888;
+        padding: 12px;
+        border: none;
+    }
+
+    QTabBar::tab:selected {
+        color: #4caf50;
+        font-weight: bold;
+    }
+
+    QScrollBar:vertical {
+        background: #2c2c2c;
+        width: 10px;
+        margin: 0px 0px 0px 0px;
+    }
+
+    QScrollBar::handle:vertical {
+        background: #555;
+        min-height: 20px;
+        border-radius: 5px;
+    }
+
+    QScrollBar::handle:vertical:hover {
+        background: #666;
+    }
+
+    QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
+        height: 0;
+    }
+"""
+
+LIGHT_STYLESHEET = """
+    QMainWindow {
+        background-color: #ffffff;
+    }
+
+    QTabWidget::pane {
+        border: none;
+    }
+
+    QWidget {
+        background-color: #ffffff;
+        color: #000000;
+        font-family: "Segoe UI", "Arial", sans-serif;
+        font-size: 14px;
+    }
+
+    QPushButton {
+        background-color: #007bff;
+        color: #ffffff;
+        padding: 8px 16px;
+        border: none;
+        border-radius: 6px;
+        font-weight: 500;
+    }
+
+    QPushButton:hover {
+        background-color: #339cff;
+    }
+
+    QPushButton:pressed {
+        background-color: #0062cc;
+    }
+
+    QPushButton:disabled {
+        background-color: #cccccc;
+        color: #666666;
+    }
+
+    QTextEdit, QLineEdit {
+        background-color: #ffffff;
+        color: #000000;
+        padding: 8px;
+        border: 1px solid #aaaaaa;
+        border-radius: 6px;
+        font-family: monospace;
+    }
+
+    QTextEdit:disabled, QLineEdit:disabled, QComboBox:disabled {
+        background-color: #eeeeee;
+        color: #777777;
+    }
+
+    QComboBox {
+        background-color: #ffffff;
+        color: #000000;
+        padding: 6px;
+        border: 1px solid #aaaaaa;
+        border-radius: 6px;
+    }
+
+    QComboBox QAbstractItemView {
+        background-color: #ffffff;
+        selection-background-color: #339cff;
+        selection-color: black;
+    }
+
+    QTabBar::tab {
+        background: transparent;
+        color: #444444;
+        padding: 12px;
+        border: none;
+    }
+
+    QTabBar::tab:selected {
+        color: #007bff;
+        font-weight: bold;
+    }
+
+    QScrollBar:vertical {
+        background: #ffffff;
+        width: 10px;
+        margin: 0px 0px 0px 0px;
+    }
+
+    QScrollBar::handle:vertical {
+        background: #cccccc;
+        min-height: 20px;
+        border-radius: 5px;
+    }
+
+    QScrollBar::handle:vertical:hover {
+        background: #bbbbbb;
+    }
+
+    QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
+        height: 0;
+    }
+"""
+
+THEME_STYLES = {"dark": DARK_STYLESHEET, "light": LIGHT_STYLESHEET}
+
+def apply_theme(widget: QMainWindow, theme: str) -> None:
+    widget.setStyleSheet(THEME_STYLES.get(theme, DARK_STYLESHEET))
+
 class MainWindow(QMainWindow):
     def __init__(self):
         super().__init__()
         self.setWindowTitle("Fusor – Laravel/PHP QA Toolbox")
         self.resize(1024, 768)
-
-
-        self.setStyleSheet("""
-            QMainWindow {
-                background-color: #1e1e1e;
-            }
-
-            QTabWidget::pane {
-                border: none;
-            }
-
-            QWidget {
-                background-color: #1e1e1e;
-                color: #dddddd;
-                font-family: "Segoe UI", "Arial", sans-serif;
-                font-size: 14px;
-            }
-
-            QPushButton {
-                background-color: #2e7d32;
-                color: #ffffff;
-                padding: 8px 16px;
-                border: none;
-                border-radius: 6px;
-                font-weight: 500;
-            }
-
-            QPushButton:hover {
-                background-color: #388e3c;
-            }
-
-            QPushButton:pressed {
-                background-color: #1b5e20;
-            }
-
-            QPushButton:disabled {
-                background-color: #555555;
-                color: #999999;
-            }
-
-            QTextEdit, QLineEdit {
-                background-color: #2c2c2c;
-                color: #eeeeee;
-                padding: 8px;
-                border: 1px solid #444444;
-                border-radius: 6px;
-                font-family: monospace;
-            }
-
-            QTextEdit:disabled, QLineEdit:disabled, QComboBox:disabled {
-                background-color: #3a3a3a;
-                color: #777777;
-            }
-
-            QComboBox {
-                background-color: #2c2c2c;
-                color: #eeeeee;
-                padding: 6px;
-                border: 1px solid #444444;
-                border-radius: 6px;
-            }
-
-            QComboBox QAbstractItemView {
-                background-color: #2c2c2c;
-                selection-background-color: #388e3c;
-                selection-color: white;
-            }
-
-            QTabBar::tab {
-                background: transparent;
-                color: #888888;
-                padding: 12px;
-                border: none;
-            }
-
-            QTabBar::tab:selected {
-                color: #4caf50;
-                font-weight: bold;
-            }
-
-            QScrollBar:vertical {
-                background: #2c2c2c;
-                width: 10px;
-                margin: 0px 0px 0px 0px;
-            }
-
-            QScrollBar::handle:vertical {
-                background: #555;
-                min-height: 20px;
-                border-radius: 5px;
-            }
-
-            QScrollBar::handle:vertical:hover {
-                background: #666;
-            }
-
-            QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
-                height: 0;
-            }
-        """)
+        self.theme = "dark"
 
         self.tabs = QTabWidget()
-
         central_widget = QWidget()
         main_layout = QVBoxLayout(central_widget)
 
@@ -188,6 +291,7 @@ class MainWindow(QMainWindow):
         self.git_remote = ""
         self.auto_refresh_secs = 5
         self.load_config()
+        apply_theme(self, self.theme)
 
         # initialize tabs
         self.project_tab = ProjectTab(self)
@@ -287,6 +391,7 @@ class MainWindow(QMainWindow):
             "auto_refresh_secs",
             data.get("auto_refresh_secs", self.auto_refresh_secs),
         )
+        self.theme = data.get("theme", self.theme)
 
         self._geom_size = data.get("window_size")
         self._geom_pos = data.get("window_position")
@@ -491,6 +596,7 @@ class MainWindow(QMainWindow):
         git_remote = self.remote_combo.currentText() if hasattr(self, "remote_combo") else self.git_remote
         compose_text = self.compose_files_edit.text() if hasattr(self, "compose_files_edit") else ";".join(self.compose_files)
         auto_refresh_secs = self.refresh_spin.value() if hasattr(self, "refresh_spin") else self.auto_refresh_secs
+        theme = self.theme_combo.currentText().lower() if hasattr(self, "theme_combo") else self.theme
 
         if (
             not project_path
@@ -531,6 +637,7 @@ class MainWindow(QMainWindow):
         self.git_remote = git_remote
         self.compose_files = [f for f in compose_text.split(";") if f]
         self.auto_refresh_secs = int(auto_refresh_secs)
+        self.theme = theme
 
         data = load_config()
         settings = data.get("project_settings", {})
@@ -550,12 +657,14 @@ class MainWindow(QMainWindow):
             "projects": self.projects,
             "current_project": project_path,
             "project_settings": settings,
+            "theme": self.theme,
         })
         try:
             save_config(data)
         except OSError as e:
             print(f"Failed to write config: {e}")
 
+        apply_theme(self, self.theme)
         print("Settings saved!")
         self.mark_settings_saved()
 

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -112,6 +112,12 @@ class SettingsTab(QWidget):
         self.refresh_spin.setValue(self.main_window.auto_refresh_secs)
         form.addRow("Auto refresh (seconds):", self.refresh_spin)
 
+        self.theme_combo = QComboBox()
+        self.theme_combo.addItems(["Dark", "Light"])
+        if getattr(self.main_window, "theme", "dark") == "light":
+            self.theme_combo.setCurrentText("Light")
+        form.addRow("Theme:", self.theme_combo)
+
         self.yii_template_combo = QComboBox()
         self.yii_template_combo.addItems(["basic", "advanced"])
         if hasattr(self.main_window, "yii_template"):
@@ -146,6 +152,7 @@ class SettingsTab(QWidget):
         self.main_window.remote_combo = self.remote_combo
         self.main_window.compose_files_edit = self.compose_files_edit
         self.main_window.refresh_spin = self.refresh_spin
+        self.main_window.theme_combo = self.theme_combo
 
         self.on_docker_toggled(self.docker_checkbox.isChecked())
         current_fw = self.framework_combo.currentText()
@@ -164,6 +171,7 @@ class SettingsTab(QWidget):
         self.yii_template_combo.currentTextChanged.connect(self.main_window.mark_settings_dirty)
         self.docker_checkbox.toggled.connect(self.main_window.mark_settings_dirty)
         self.refresh_spin.valueChanged.connect(self.main_window.mark_settings_dirty)
+        self.theme_combo.currentTextChanged.connect(self.main_window.mark_settings_dirty)
 
     def _wrap(self, child):
         """Return a QWidget containing the given layout or widget."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,7 @@ def test_save_then_load(tmp_path, monkeypatch):
                 "auto_refresh_secs": 7,
             }
         },
+        "theme": "light",
         "window_size": [800, 600],
         "window_position": [10, 20],
     }

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -642,3 +642,32 @@ class TestMainWindow:
 
         assert saved["window_size"] == [777, 555]
         assert saved["window_position"] == [11, 22]
+
+    def test_theme_applied_from_config(self, qtbot, monkeypatch):
+        monkeypatch.setattr(QTimer, "singleShot", lambda *a, **k: None, raising=True)
+        monkeypatch.setattr(mw_module, "load_config", lambda: {"theme": "light"}, raising=True)
+        monkeypatch.setattr(mw_module, "save_config", lambda *a, **k: None, raising=True)
+
+        win = MainWindow()
+        qtbot.addWidget(win)
+        win.show()
+
+        assert win.styleSheet() == mw_module.LIGHT_STYLESHEET
+        win.close()
+
+    def test_save_settings_persists_theme(self, main_window, monkeypatch):
+        main_window.project_combo.addItem("/tmp")
+        main_window.project_combo.setCurrentText("/tmp")
+        main_window.project_path = "/tmp"
+        main_window.theme_combo.setCurrentText("Light")
+
+        monkeypatch.setattr(os.path, "isdir", lambda p: True, raising=True)
+        monkeypatch.setattr(os.path, "isfile", lambda p: False, raising=True)
+        monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/php" if cmd == "php" else None, raising=True)
+        saved = {}
+        monkeypatch.setattr(mw_module, "save_config", lambda data: saved.update(data), raising=True)
+
+        main_window.save_settings()
+
+        assert saved["theme"] == "light"
+        assert main_window.styleSheet() == mw_module.LIGHT_STYLESHEET


### PR DESCRIPTION
## Summary
- support dark and light themes via constants
- store `theme` in config and apply selected theme
- add theme selector to Settings tab
- document theme selector
- test theme loading and saving

## Testing
- `pytest -q`