### PR TITLE
Switch server port field to QSpinBox

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -337,7 +337,7 @@ class MainWindow(QMainWindow):
         if hasattr(self, "php_service_edit"):
             self.php_service_edit.setText(self.php_service)
         if hasattr(self, "server_port_edit"):
-            self.server_port_edit.setText(str(self.server_port))
+            self.server_port_edit.setValue(self.server_port)
         if hasattr(self, "docker_checkbox"):
             self.docker_checkbox.setChecked(self.use_docker)
         if hasattr(self, "yii_template_combo"):
@@ -485,7 +485,7 @@ class MainWindow(QMainWindow):
         framework = self.framework_combo.currentText()
         php_path = self.php_path_edit.text()
         php_service = self.php_service_edit.text() if hasattr(self, "php_service_edit") else self.php_service
-        port_text = self.server_port_edit.text() if hasattr(self, "server_port_edit") else str(self.server_port)
+        server_port = self.server_port_edit.value() if hasattr(self, "server_port_edit") else self.server_port
         use_docker = self.docker_checkbox.isChecked()
         yii_template = self.yii_template_combo.currentText() if hasattr(self, "yii_template_combo") else self.yii_template
         log_path = self.log_path_edit.text() if hasattr(self, "log_path_edit") else self.log_path
@@ -497,7 +497,7 @@ class MainWindow(QMainWindow):
             not project_path
             or (not php_path and not use_docker)
             or (use_docker and not php_service)
-            or not port_text.isdigit()
+            or server_port <= 0
         ):
             QMessageBox.warning(self, "Invalid settings", "All settings fields must be filled out.")
             print("Failed to save settings: one or more fields were empty")
@@ -517,7 +517,6 @@ class MainWindow(QMainWindow):
                 print(f"Failed to save settings: php not found - {php_path}")
                 return
 
-        server_port = int(port_text)
 
         self.project_path = project_path
         if project_path not in self.projects:

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -60,7 +60,9 @@ class SettingsTab(QWidget):
         self.php_service_edit = QLineEdit(self.main_window.php_service)
         form.addRow("PHP Service:", self.php_service_edit)
 
-        self.server_port_edit = QLineEdit(str(self.main_window.server_port))
+        self.server_port_edit = QSpinBox()
+        self.server_port_edit.setRange(1, 65535)
+        self.server_port_edit.setValue(self.main_window.server_port)
         form.addRow("Server Port:", self.server_port_edit)
 
         self.compose_files_edit = QLineEdit(";".join(self.main_window.compose_files))
@@ -158,7 +160,7 @@ class SettingsTab(QWidget):
         self.project_combo.currentTextChanged.connect(self.main_window.mark_settings_dirty)
         self.php_path_edit.textChanged.connect(self.main_window.mark_settings_dirty)
         self.php_service_edit.textChanged.connect(self.main_window.mark_settings_dirty)
-        self.server_port_edit.textChanged.connect(self.main_window.mark_settings_dirty)
+        self.server_port_edit.valueChanged.connect(self.main_window.mark_settings_dirty)
         self.framework_combo.currentTextChanged.connect(self.main_window.mark_settings_dirty)
         self.log_path_edit.textChanged.connect(self.main_window.mark_settings_dirty)
         self.yii_template_combo.currentTextChanged.connect(self.main_window.mark_settings_dirty)

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -523,7 +523,7 @@ class TestMainWindow:
         main_window.project_path = "/tmp"
         main_window.php_path_edit.setText("php")
         main_window.docker_checkbox.setChecked(False)
-        main_window.server_port_edit.setText("8000")
+        main_window.server_port_edit.setValue(8000)
 
         monkeypatch.setattr(os.path, "isdir", lambda p: True, raising=True)
         monkeypatch.setattr(os.path, "isfile", lambda p: False, raising=True)
@@ -562,13 +562,13 @@ class TestMainWindow:
         win.show()
 
         assert win.server_port == 8000
-        assert win.server_port_edit.text() == "8000"
+        assert win.server_port_edit.value() == 8000
 
         win.project_combo.setCurrentText("/two")
         qtbot.wait(10)
 
         assert win.server_port == 8001
-        assert win.server_port_edit.text() == "8001"
+        assert win.server_port_edit.value() == 8001
         win.close()
 
     def test_open_terminal_launches_with_project_cwd(self, tmp_path: Path, main_window, qtbot, monkeypatch):


### PR DESCRIPTION
## Summary
- tweak settings tab to use QSpinBox for server port
- update main window logic for QSpinBox
- fix tests for new widget type

## Testing
- `ruff check .`
- `mypy fusor`
- `pytest -q`