### PR TITLE
Fix git command errors when project directory missing

### DIFF
--- a/fusor/tabs/git_tab.py
+++ b/fusor/tabs/git_tab.py
@@ -11,6 +11,7 @@ from PyQt6.QtWidgets import (
     QLineEdit,
 )
 from PyQt6.QtCore import QTimer
+import os
 
 import subprocess
 
@@ -93,6 +94,8 @@ class GitTab(QWidget):
         """Run ``git`` with the given ``args`` in a background thread."""
         if not self.main_window.ensure_project_path():
             return None
+        if not os.path.isdir(self.main_window.project_path):
+            return None
 
         command = ["git", *args]
         print(f"$ {' '.join(command)}")
@@ -117,7 +120,9 @@ class GitTab(QWidget):
         return self.main_window.executor.submit(task)
 
     def load_branches(self):
-        if not self.main_window.project_path:
+        if not self.main_window.project_path or not os.path.isdir(
+            self.main_window.project_path
+        ):
             return None
 
         def task():
@@ -229,7 +234,7 @@ class GitTab(QWidget):
         remote = self.main_window.git_remote
         self.remote_branch_combo.blockSignals(True)
         self.remote_branch_combo.clear()
-        if not remote:
+        if not remote or not os.path.isdir(self.main_window.project_path):
             self.remote_branch_combo.blockSignals(False)
             return None
 

--- a/tests/test_git_tab.py
+++ b/tests/test_git_tab.py
@@ -1,4 +1,5 @@
 import subprocess
+import os
 from PyQt6.QtWidgets import QMessageBox, QPushButton
 from PyQt6.QtCore import Qt
 
@@ -32,6 +33,8 @@ def test_load_branches_and_run_git_command(monkeypatch, qtbot):
     main = DummyMainWindow()
     tab = GitTab(main)
     qtbot.addWidget(tab)
+
+    monkeypatch.setattr(os.path, "isdir", lambda p: True, raising=True)
 
     results = {}
 
@@ -127,6 +130,7 @@ def test_remote_helpers(monkeypatch, qtbot):
     main = DummyMainWindow()
     tab = GitTab(main)
     qtbot.addWidget(tab)
+    monkeypatch.setattr(os.path, "isdir", lambda p: True, raising=True)
 
     class DummyResult:
         def __init__(self, stdout=""):

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -506,6 +506,7 @@ class TestMainWindow:
         monkeypatch.setattr(mw_module, "save_config", lambda data: saved.update(data), raising=True)
         monkeypatch.setattr(os.path, "isdir", lambda p: True, raising=True)
         monkeypatch.setattr(os.path, "isfile", lambda p: True, raising=True)
+        monkeypatch.setattr(mw_module.GitTab, "load_branches", lambda self: None, raising=True)
         monkeypatch.setattr(
             "PyQt6.QtWidgets.QMessageBox.warning", lambda *a, **k: None, raising=True
         )


### PR DESCRIPTION
## Summary
- avoid running git commands when the configured project directory does not exist
- update tests to mock the directory check and skip `load_branches` during project removal

## Testing
- `ruff check .`
- `pytest -q`