### PR TITLE
Prevent tests from creating user config

### DIFF
--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -570,6 +570,7 @@ class TestMainWindow:
             },
             raising=True,
         )
+        monkeypatch.setattr(mw_module, "save_config", lambda *a, **k: None, raising=True)
 
         win = MainWindow()
         qtbot.addWidget(win)


### PR DESCRIPTION
## Summary
- patch `test_project_change_updates_settings` to stub `save_config`
- ensure tests don't write a bogus `~/.fusor_config.json`

## Testing
- `pytest -q`