### PR TITLE
Fix compose file parsing

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -672,7 +672,7 @@ class MainWindow(QMainWindow):
         self.yii_template = yii_template
         self.log_path = log_path
         self.git_remote = git_remote
-        self.compose_files = [f for f in compose_text.split(";") if f]
+        self.compose_files = [p.strip() for p in compose_text.split(";") if p.strip()]
         self.auto_refresh_secs = int(auto_refresh_secs)
         self.theme = theme
         self.max_log_lines = int(getattr(self, "max_log_lines", MAX_LOG_LINES))

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -786,3 +786,19 @@ class TestMainWindow:
 
         assert saved["theme"] == "light"
         assert main_window.styleSheet() == mw_module.LIGHT_STYLESHEET
+
+    def test_save_settings_strips_compose_files(self, main_window, monkeypatch):
+        main_window.project_combo.addItem("/tmp")
+        main_window.project_combo.setCurrentText("/tmp")
+        main_window.project_path = "/tmp"
+        main_window.docker_checkbox.setChecked(True)
+        main_window.compose_files_edit.setText(" a.yml ; b.yml ;  ")
+
+        monkeypatch.setattr(os.path, "isdir", lambda p: True, raising=True)
+        saved = {}
+        monkeypatch.setattr(mw_module, "save_config", lambda data: saved.update(data), raising=True)
+
+        main_window.save_settings()
+
+        assert main_window.compose_files == ["a.yml", "b.yml"]
+        assert saved["project_settings"]["/tmp"]["compose_files"] == ["a.yml", "b.yml"]


### PR DESCRIPTION
## Summary
- trim whitespace when parsing Docker compose files in settings
- test that compose paths are stripped before saving

## Testing
- `pytest -q`