### PR TITLE
Add macOS terminal support

### DIFF
--- a/fusor/tabs/project_tab.py
+++ b/fusor/tabs/project_tab.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 from PyQt6.QtWidgets import (
     QWidget,
     QVBoxLayout,
@@ -87,8 +88,14 @@ class ProjectTab(QWidget):
             print("Project path not set")
             return
 
-        cmd = ["cmd.exe"] if os.name == "nt" else ["x-terminal-emulator"]
+        if sys.platform == "darwin":
+            cmd = ["open", "-a", "Terminal", path]
+            cwd = None
+        else:
+            cmd = ["cmd.exe"] if os.name == "nt" else ["x-terminal-emulator"]
+            cwd = path
+
         try:
-            subprocess.Popen(cmd, cwd=path)
+            subprocess.Popen(cmd, cwd=cwd)
         except FileNotFoundError:
             print(f"Command not found: {cmd[0]}")

--- a/tests/test_project_tab.py
+++ b/tests/test_project_tab.py
@@ -1,0 +1,72 @@
+import os
+import sys
+import subprocess
+
+from fusor.tabs.project_tab import ProjectTab
+
+
+class DummyMainWindow:
+    def __init__(self, path="/proj"):
+        self.project_path = path
+        # methods required by ProjectTab but unused in these tests
+        self.start_project = lambda: None
+        self.stop_project = lambda: None
+        self.phpunit = lambda: None
+        self.run_command = lambda *a, **k: None
+
+
+def make_tab(qtbot):
+    main = DummyMainWindow()
+    tab = ProjectTab(main)
+    qtbot.addWidget(tab)
+    return tab, main
+
+
+def capture_popen(monkeypatch):
+    captured = {}
+
+    def fake_popen(cmd, cwd=None):
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        class D:
+            pass
+        return D()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen, raising=True)
+    return captured
+
+
+def test_open_terminal_macos(monkeypatch, qtbot):
+    tab, main = make_tab(qtbot)
+    captured = capture_popen(monkeypatch)
+    monkeypatch.setattr(sys, "platform", "darwin", raising=False)
+    monkeypatch.setattr(os, "name", "posix", raising=False)
+
+    tab.open_terminal()
+
+    assert captured["cmd"] == ["open", "-a", "Terminal", main.project_path]
+    assert captured["cwd"] is None
+
+
+def test_open_terminal_windows(monkeypatch, qtbot):
+    tab, main = make_tab(qtbot)
+    captured = capture_popen(monkeypatch)
+    monkeypatch.setattr(sys, "platform", "win32", raising=False)
+    monkeypatch.setattr(os, "name", "nt", raising=False)
+
+    tab.open_terminal()
+
+    assert captured["cmd"] == ["cmd.exe"]
+    assert captured["cwd"] == main.project_path
+
+
+def test_open_terminal_linux(monkeypatch, qtbot):
+    tab, main = make_tab(qtbot)
+    captured = capture_popen(monkeypatch)
+    monkeypatch.setattr(sys, "platform", "linux", raising=False)
+    monkeypatch.setattr(os, "name", "posix", raising=False)
+
+    tab.open_terminal()
+
+    assert captured["cmd"] == ["x-terminal-emulator"]
+    assert captured["cwd"] == main.project_path


### PR DESCRIPTION
## Summary
- support macOS in `ProjectTab.open_terminal`
- test terminal launching logic on macOS, Windows, and Linux

## Testing
- `ruff check .`
- `mypy fusor`
- `pytest -q`