### PR TITLE
Refactor workflows for separate linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Lint
 
 on:
   push:
@@ -6,30 +6,20 @@ on:
   pull_request:
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
-    needs: lint
-    env:
-      QT_QPA_PLATFORM: offscreen
     steps:
       - uses: actions/checkout@v3
-
-      - name: Install Qt runtime libs
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libegl1 \
-            libgl1 \
-            libxkbcommon-x11-0
-
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
-      - name: Run tests
-        run: pytest -q
+      - name: Run ruff
+        run: ruff check .
+      - name: Run mypy
+        run: mypy fusor


### PR DESCRIPTION
## Summary
- add CI workflow `lint.yml` running ruff and mypy
- strip lint steps from `tests.yml` and make it depend on lint
- use the same Python 3.11 and pip cache in both jobs

## Testing
- `ruff check .`
- `mypy fusor`
- `pytest -q`
- `./act pull_request -n -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68796dc993ac832296e6363bc5f6f3d1