### PR TITLE
Add Symfony framework support

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -27,6 +27,7 @@ from .tabs.project_tab import ProjectTab
 from .tabs.git_tab import GitTab
 from .tabs.database_tab import DatabaseTab
 from .tabs.framework_tab import FrameworkTab
+from .tabs.symfony_tab import SymfonyTab
 from .tabs.docker_tab import DockerTab
 from .tabs.logs_tab import LogsTab
 from .tabs.settings_tab import SettingsTab
@@ -314,6 +315,9 @@ class MainWindow(QMainWindow):
         self.framework_tab = FrameworkTab(self)
         self.framework_index = self.tabs.addTab(self.framework_tab, "Framework")
 
+        self.symfony_tab = SymfonyTab(self)
+        self.symfony_index = self.tabs.addTab(self.symfony_tab, "Symfony")
+
         self.docker_tab = DockerTab(self)
         self.docker_index = self.tabs.addTab(self.docker_tab, "Docker")
 
@@ -329,9 +333,13 @@ class MainWindow(QMainWindow):
         self.tabs.setTabEnabled(self.docker_index, self.use_docker)
 
         # framework tab availability
-        show_fw = self.framework_choice != "None"
+        show_fw = self.framework_choice == "Laravel"
         self.tabs.setTabVisible(self.framework_index, show_fw)
         self.tabs.setTabEnabled(self.framework_index, show_fw)
+
+        show_symfony = self.framework_choice == "Symfony"
+        self.tabs.setTabVisible(self.symfony_index, show_symfony)
+        self.tabs.setTabEnabled(self.symfony_index, show_symfony)
 
         # populate settings widgets with loaded values
         if hasattr(self, "project_combo"):
@@ -719,17 +727,28 @@ class MainWindow(QMainWindow):
         artisan_file = os.path.join(self.project_path, "artisan")
         self.run_command([self.php_path, artisan_file, *args])
 
+    def symfony(self, *args):
+        self.ensure_project_path()
+        console = os.path.join(self.project_path, "bin", "console")
+        self.run_command([self.php_path, console, *args])
+
     def migrate(self):
-        if self.current_framework() == "Laravel":
+        fw = self.current_framework()
+        if fw == "Laravel":
             self.artisan("migrate")
+        elif fw == "Symfony":
+            self.symfony("doctrine:migrations:migrate")
         else:
-            print(f"Migrate not implemented for {self.current_framework()}")
+            print(f"Migrate not implemented for {fw}")
 
     def rollback(self):
-        if self.current_framework() == "Laravel":
+        fw = self.current_framework()
+        if fw == "Laravel":
             self.artisan("migrate:rollback")
+        elif fw == "Symfony":
+            self.symfony("doctrine:migrations:migrate", "prev")
         else:
-            print(f"Rollback not implemented for {self.current_framework()}")
+            print(f"Rollback not implemented for {fw}")
 
     def fresh(self):
         if self.current_framework() == "Laravel":

--- a/fusor/tabs/__init__.py
+++ b/fusor/tabs/__init__.py
@@ -1,0 +1,3 @@
+from .symfony_tab import SymfonyTab
+
+__all__ = ["SymfonyTab"]

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -91,8 +91,8 @@ class SettingsTab(QWidget):
         form.addRow("Git Remote:", self.remote_combo)
 
         self.framework_combo = QComboBox()
-        self.framework_combo.addItems(["Laravel", "Yii", "None"])
-        if self.main_window.framework_choice in ["Laravel", "Yii", "None"]:
+        self.framework_combo.addItems(["Laravel", "Yii", "Symfony", "None"])
+        if self.main_window.framework_choice in ["Laravel", "Yii", "Symfony", "None"]:
             self.framework_combo.setCurrentText(self.main_window.framework_choice)
         self.framework_combo.currentTextChanged.connect(self.on_framework_changed)
         self.framework_combo.currentTextChanged.connect(
@@ -101,6 +101,10 @@ class SettingsTab(QWidget):
         if hasattr(self.main_window, "framework_tab"):
             self.framework_combo.currentTextChanged.connect(
                 self.main_window.framework_tab.on_framework_changed
+            )
+        if hasattr(self.main_window, "symfony_tab"):
+            self.framework_combo.currentTextChanged.connect(
+                self.main_window.symfony_tab.on_framework_changed
             )
         form.addRow("Framework:", self.framework_combo)
 
@@ -170,6 +174,8 @@ class SettingsTab(QWidget):
         self.main_window.database_tab.on_framework_changed(current_fw)
         if hasattr(self.main_window, "framework_tab"):
             self.main_window.framework_tab.on_framework_changed(current_fw)
+        if hasattr(self.main_window, "symfony_tab"):
+            self.main_window.symfony_tab.on_framework_changed(current_fw)
 
         # track unsaved changes
         self.project_combo.currentTextChanged.connect(self.main_window.mark_settings_dirty)
@@ -227,6 +233,8 @@ class SettingsTab(QWidget):
                 for name in ["yii", "yii.bat"]
             ):
                 framework = "Yii"
+            elif os.path.isfile(os.path.join(directory, "bin", "console")):
+                framework = "Symfony"
             self.framework_combo.setCurrentText(framework)
             if hasattr(self.main_window, "framework_combo"):
                 self.main_window.framework_combo.setCurrentText(framework)
@@ -288,8 +296,14 @@ class SettingsTab(QWidget):
             self.main_window.database_tab.on_framework_changed(text)
         if hasattr(self.main_window, "framework_tab"):
             self.main_window.framework_tab.on_framework_changed(text)
+        if hasattr(self.main_window, "symfony_tab"):
+            self.main_window.symfony_tab.on_framework_changed(text)
         if hasattr(self.main_window, "framework_index"):
-            show_fw = text != "None"
+            show_fw = text == "Laravel"
             self.main_window.tabs.setTabVisible(self.main_window.framework_index, show_fw)
             self.main_window.tabs.setTabEnabled(self.main_window.framework_index, show_fw)
+        if hasattr(self.main_window, "symfony_index"):
+            show_sy = text == "Symfony"
+            self.main_window.tabs.setTabVisible(self.main_window.symfony_index, show_sy)
+            self.main_window.tabs.setTabEnabled(self.main_window.symfony_index, show_sy)
 

--- a/fusor/tabs/symfony_tab.py
+++ b/fusor/tabs/symfony_tab.py
@@ -1,0 +1,68 @@
+from PyQt6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QPushButton,
+    QSizePolicy,
+    QGroupBox,
+)
+
+from ..icons import get_icon
+
+
+class SymfonyTab(QWidget):
+    def __init__(self, main_window):
+        super().__init__()
+        self.main_window = main_window
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(20, 20, 20, 20)
+        layout.setSpacing(20)
+
+        self.console_group = QGroupBox("Symfony Console")
+        console_layout = QVBoxLayout()
+        console_layout.setSpacing(10)
+
+        self.cache_clear_btn = self._btn(
+            "Cache Clear",
+            lambda: self.main_window.symfony("cache:clear"),
+            icon="view-refresh",
+        )
+        self.migrate_btn = self._btn(
+            "Migrate",
+            lambda: self.main_window.symfony("doctrine:migrations:migrate"),
+            icon="system-run",
+        )
+        self.status_btn = self._btn(
+            "Migration Status",
+            lambda: self.main_window.symfony("doctrine:migrations:status"),
+            icon="dialog-information",
+        )
+        self.make_migration_btn = self._btn(
+            "Make Migration",
+            lambda: self.main_window.symfony("make:migration"),
+            icon="document-new",
+        )
+
+        console_layout.addWidget(self.cache_clear_btn)
+        console_layout.addWidget(self.migrate_btn)
+        console_layout.addWidget(self.status_btn)
+        console_layout.addWidget(self.make_migration_btn)
+        self.console_group.setLayout(console_layout)
+        layout.addWidget(self.console_group)
+
+        layout.addStretch(1)
+
+        self.on_framework_changed(self.main_window.framework_choice)
+
+    def _btn(self, text, slot, icon: str | None = None):
+        btn = QPushButton(text)
+        if icon:
+            btn.setIcon(get_icon(icon))
+        btn.setMinimumHeight(36)
+        btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        btn.clicked.connect(slot)
+        return btn
+
+    def on_framework_changed(self, text: str):
+        visible = text == "Symfony"
+        self.console_group.setVisible(visible)
+

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -251,6 +251,20 @@ class TestMainWindow:
         assert main_window.tabs.isTabVisible(main_window.framework_index)
         assert main_window.tabs.isTabEnabled(main_window.framework_index)
 
+    def test_symfony_tab_visibility(self, main_window, qtbot):
+        assert not main_window.tabs.isTabVisible(main_window.symfony_index)
+        assert not main_window.tabs.isTabEnabled(main_window.symfony_index)
+
+        main_window.framework_combo.setCurrentText("Symfony")
+        qtbot.wait(10)
+        assert main_window.tabs.isTabVisible(main_window.symfony_index)
+        assert main_window.tabs.isTabEnabled(main_window.symfony_index)
+
+        main_window.framework_combo.setCurrentText("Laravel")
+        qtbot.wait(10)
+        assert not main_window.tabs.isTabVisible(main_window.symfony_index)
+        assert not main_window.tabs.isTabEnabled(main_window.symfony_index)
+
     def test_composer_install_button_runs_command(self, main_window, qtbot, monkeypatch):
         captured = []
         monkeypatch.setattr(main_window, "run_command", lambda cmd: captured.append(cmd), raising=True)

--- a/tests/test_settings_tab.py
+++ b/tests/test_settings_tab.py
@@ -1,0 +1,50 @@
+from fusor.tabs.settings_tab import SettingsTab
+from PyQt6.QtWidgets import QFileDialog
+
+
+class DummyMainWindow:
+    def __init__(self):
+        self.projects = []
+        self.project_path = ""
+        self.framework_choice = "None"
+        self.php_path = "php"
+        self.php_service = "php"
+        self.server_port = 8000
+        self.compose_files = []
+        self.use_docker = False
+        self.yii_template = "basic"
+        self.log_path = ""
+        self.auto_refresh_secs = 5
+        self.theme = "dark"
+        self.git_remote = ""
+        self.git_tab = type("G", (), {"get_remotes": lambda self: []})()
+        self.database_tab = type("D", (), {"on_framework_changed": lambda self, t: None})()
+        self.mark_settings_dirty = lambda *a, **k: None
+
+    def set_current_project(self, path: str):
+        self.project_path = path
+
+    def save_settings(self):
+        pass
+
+
+def test_add_project_detects_symfony(tmp_path, monkeypatch, qtbot):
+    (tmp_path / "bin").mkdir()
+    (tmp_path / "bin" / "console").touch()
+
+    main = DummyMainWindow()
+    tab = SettingsTab(main)
+    qtbot.addWidget(tab)
+
+    monkeypatch.setattr(
+        QFileDialog,
+        "getExistingDirectory",
+        lambda *a, **k: str(tmp_path),
+        raising=True,
+    )
+
+    tab.add_project()
+
+    assert tab.framework_combo.currentText() == "Symfony"
+    assert main.project_path == str(tmp_path)
+

--- a/tests/test_symfony_tab.py
+++ b/tests/test_symfony_tab.py
@@ -1,0 +1,43 @@
+from PyQt6.QtCore import Qt
+
+from fusor.tabs.symfony_tab import SymfonyTab
+
+
+class DummyMainWindow:
+    def __init__(self):
+        self.commands = []
+        self.framework_choice = "Symfony"
+
+    def symfony(self, *args):
+        self.commands.append(list(args))
+
+
+def test_buttons_run_commands(qtbot):
+    main = DummyMainWindow()
+    tab = SymfonyTab(main)
+    qtbot.addWidget(tab)
+
+    qtbot.mouseClick(tab.cache_clear_btn, Qt.MouseButton.LeftButton)
+    qtbot.mouseClick(tab.migrate_btn, Qt.MouseButton.LeftButton)
+    qtbot.mouseClick(tab.status_btn, Qt.MouseButton.LeftButton)
+    qtbot.mouseClick(tab.make_migration_btn, Qt.MouseButton.LeftButton)
+
+    assert main.commands == [
+        ["cache:clear"],
+        ["doctrine:migrations:migrate"],
+        ["doctrine:migrations:status"],
+        ["make:migration"],
+    ]
+
+
+def test_visibility_changes(qtbot):
+    main = DummyMainWindow()
+    tab = SymfonyTab(main)
+    qtbot.addWidget(tab)
+
+    tab.on_framework_changed("None")
+    assert tab.console_group.isHidden()
+
+    tab.on_framework_changed("Symfony")
+    assert not tab.console_group.isHidden()
+


### PR DESCRIPTION
## Summary
- add Symfony to frameworks list and detect bin/console projects
- create SymfonyTab with console helpers
- show/hide framework tabs when Symfony is selected
- run Symfony console for migrations
- test Symfony tab visibility, command execution, and detection logic

## Testing
- `ruff check .`
- `mypy fusor`
- `pytest -q`