### PR TITLE
Rename Framework tab to Laravel

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -26,7 +26,7 @@ from .qtextedit_logger import QTextEditLogger
 from .tabs.project_tab import ProjectTab
 from .tabs.git_tab import GitTab
 from .tabs.database_tab import DatabaseTab
-from .tabs.framework_tab import FrameworkTab
+from .tabs.laravel_tab import LaravelTab
 from .tabs.symfony_tab import SymfonyTab
 from .tabs.docker_tab import DockerTab
 from .tabs.logs_tab import LogsTab
@@ -313,8 +313,8 @@ class MainWindow(QMainWindow):
         self.database_tab = DatabaseTab(self)
         self.tabs.addTab(self.database_tab, "Database")
 
-        self.framework_tab = FrameworkTab(self)
-        self.framework_index = self.tabs.addTab(self.framework_tab, "Framework")
+        self.laravel_tab = LaravelTab(self)
+        self.laravel_index = self.tabs.addTab(self.laravel_tab, "Laravel")
 
         self.symfony_tab = SymfonyTab(self)
         self.symfony_index = self.tabs.addTab(self.symfony_tab, "Symfony")
@@ -333,10 +333,10 @@ class MainWindow(QMainWindow):
         self.tabs.setTabVisible(self.docker_index, self.use_docker)
         self.tabs.setTabEnabled(self.docker_index, self.use_docker)
 
-        # framework tab availability
+        # laravel tab availability
         show_fw = self.framework_choice == "Laravel"
-        self.tabs.setTabVisible(self.framework_index, show_fw)
-        self.tabs.setTabEnabled(self.framework_index, show_fw)
+        self.tabs.setTabVisible(self.laravel_index, show_fw)
+        self.tabs.setTabEnabled(self.laravel_index, show_fw)
 
         show_symfony = self.framework_choice == "Symfony"
         self.tabs.setTabVisible(self.symfony_index, show_symfony)

--- a/fusor/tabs/laravel_tab.py
+++ b/fusor/tabs/laravel_tab.py
@@ -8,7 +8,7 @@ from PyQt6.QtWidgets import (
 
 from ..icons import get_icon
 
-class FrameworkTab(QWidget):
+class LaravelTab(QWidget):
     def __init__(self, main_window):
         super().__init__()
         self.main_window = main_window

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -98,9 +98,9 @@ class SettingsTab(QWidget):
         self.framework_combo.currentTextChanged.connect(
             self.main_window.database_tab.on_framework_changed
         )
-        if hasattr(self.main_window, "framework_tab"):
+        if hasattr(self.main_window, "laravel_tab"):
             self.framework_combo.currentTextChanged.connect(
-                self.main_window.framework_tab.on_framework_changed
+                self.main_window.laravel_tab.on_framework_changed
             )
         if hasattr(self.main_window, "symfony_tab"):
             self.framework_combo.currentTextChanged.connect(
@@ -177,8 +177,8 @@ class SettingsTab(QWidget):
         current_fw = self.framework_combo.currentText()
         self.on_framework_changed(current_fw)
         self.main_window.database_tab.on_framework_changed(current_fw)
-        if hasattr(self.main_window, "framework_tab"):
-            self.main_window.framework_tab.on_framework_changed(current_fw)
+        if hasattr(self.main_window, "laravel_tab"):
+            self.main_window.laravel_tab.on_framework_changed(current_fw)
         if hasattr(self.main_window, "symfony_tab"):
             self.main_window.symfony_tab.on_framework_changed(current_fw)
 
@@ -350,14 +350,14 @@ class SettingsTab(QWidget):
         self.add_log_btn.setVisible(log_visible)
         if hasattr(self.main_window, "database_tab"):
             self.main_window.database_tab.on_framework_changed(text)
-        if hasattr(self.main_window, "framework_tab"):
-            self.main_window.framework_tab.on_framework_changed(text)
+        if hasattr(self.main_window, "laravel_tab"):
+            self.main_window.laravel_tab.on_framework_changed(text)
         if hasattr(self.main_window, "symfony_tab"):
             self.main_window.symfony_tab.on_framework_changed(text)
-        if hasattr(self.main_window, "framework_index"):
+        if hasattr(self.main_window, "laravel_index"):
             show_fw = text == "Laravel"
-            self.main_window.tabs.setTabVisible(self.main_window.framework_index, show_fw)
-            self.main_window.tabs.setTabEnabled(self.main_window.framework_index, show_fw)
+            self.main_window.tabs.setTabVisible(self.main_window.laravel_index, show_fw)
+            self.main_window.tabs.setTabEnabled(self.main_window.laravel_index, show_fw)
         if hasattr(self.main_window, "symfony_index"):
             show_sy = text == "Symfony"
             self.main_window.tabs.setTabVisible(self.main_window.symfony_index, show_sy)

--- a/tests/test_laravel_tab.py
+++ b/tests/test_laravel_tab.py
@@ -1,6 +1,6 @@
 from PyQt6.QtCore import Qt
 
-from fusor.tabs.framework_tab import FrameworkTab
+from fusor.tabs.laravel_tab import LaravelTab
 
 
 class DummyMainWindow:
@@ -21,7 +21,7 @@ class DummyMainWindow:
 
 def test_artisan_buttons_run_commands(qtbot):
     main = DummyMainWindow()
-    tab = FrameworkTab(main)
+    tab = LaravelTab(main)
     qtbot.addWidget(tab)
 
     qtbot.mouseClick(tab.optimize_btn, Qt.MouseButton.LeftButton)
@@ -32,7 +32,7 @@ def test_artisan_buttons_run_commands(qtbot):
 
 def test_visibility_changes(qtbot):
     main = DummyMainWindow()
-    tab = FrameworkTab(main)
+    tab = LaravelTab(main)
     qtbot.addWidget(tab)
 
     tab.on_framework_changed("None")

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -237,19 +237,19 @@ class TestMainWindow:
         assert not main_window.tabs.isTabVisible(main_window.docker_index)
         assert not main_window.tabs.isTabEnabled(main_window.docker_index)
 
-    def test_framework_tab_visibility(self, main_window, qtbot):
-        assert main_window.tabs.isTabVisible(main_window.framework_index)
-        assert main_window.tabs.isTabEnabled(main_window.framework_index)
+    def test_laravel_tab_visibility(self, main_window, qtbot):
+        assert main_window.tabs.isTabVisible(main_window.laravel_index)
+        assert main_window.tabs.isTabEnabled(main_window.laravel_index)
 
         main_window.framework_combo.setCurrentText("None")
         qtbot.wait(10)
-        assert not main_window.tabs.isTabVisible(main_window.framework_index)
-        assert not main_window.tabs.isTabEnabled(main_window.framework_index)
+        assert not main_window.tabs.isTabVisible(main_window.laravel_index)
+        assert not main_window.tabs.isTabEnabled(main_window.laravel_index)
 
         main_window.framework_combo.setCurrentText("Laravel")
         qtbot.wait(10)
-        assert main_window.tabs.isTabVisible(main_window.framework_index)
-        assert main_window.tabs.isTabEnabled(main_window.framework_index)
+        assert main_window.tabs.isTabVisible(main_window.laravel_index)
+        assert main_window.tabs.isTabEnabled(main_window.laravel_index)
 
     def test_symfony_tab_visibility(self, main_window, qtbot):
         assert not main_window.tabs.isTabVisible(main_window.symfony_index)


### PR DESCRIPTION
## Summary
- rename `FrameworkTab` to `LaravelTab`
- rename files and references
- update tests

## Testing
- `pytest -q`
- `ruff check .`
- `mypy fusor`