### PR TITLE
Add docker compose profile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ Enable the **Use Docker** option in the Settings tab to run commands inside your
 
 -   Set **PHP Service** to match the container name in your `docker-compose.yml`
 -   Support for multiple Compose files (separated by `;`)
+-   Optional Compose profile via **Compose Profile** field
 -   The **Docker** tab will appear automatically
 
-Start/Stop buttons execute `docker compose up -d` and `docker compose down` accordingly.
+Start/Stop buttons execute `docker compose up -d` and `docker compose down` (with `--profile` if specified) accordingly.
 
 ---
 

--- a/fusor/config.py
+++ b/fusor/config.py
@@ -17,6 +17,7 @@ DEFAULT_PROJECT_SETTINGS = {
     "log_paths": [os.path.join("storage", "logs", "laravel.log")],
     "git_remote": "",
     "compose_files": [],
+    "compose_profile": "",
     "auto_refresh_secs": 5,
     "max_log_lines": 1000,
 }

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -295,6 +295,7 @@ class MainWindow(QMainWindow):
         self.server_port = 8000
         self.use_docker = False
         self.compose_files: list[str] = []
+        self.compose_profile = ""
         self.yii_template = "basic"
         self.log_path = os.path.join("storage", "logs", "laravel.log")
         self.log_paths: list[str] = [self.log_path]
@@ -423,6 +424,9 @@ class MainWindow(QMainWindow):
         self.compose_files = settings.get(
             "compose_files", data.get("compose_files", self.compose_files)
         )
+        self.compose_profile = settings.get(
+            "compose_profile", data.get("compose_profile", self.compose_profile)
+        )
         self.auto_refresh_secs = settings.get(
             "auto_refresh_secs",
             data.get("auto_refresh_secs", self.auto_refresh_secs),
@@ -442,6 +446,8 @@ class MainWindow(QMainWindow):
         prefix = ["docker", "compose"]
         for f in self.compose_files:
             prefix.extend(["-f", f])
+        if self.compose_profile:
+            prefix.extend(["--profile", self.compose_profile])
         return prefix
 
     def update_settings_tab_title(self):
@@ -483,6 +489,7 @@ class MainWindow(QMainWindow):
         self.log_path = self.log_paths[0]
         self.git_remote = settings["git_remote"]
         self.compose_files = settings["compose_files"]
+        self.compose_profile = settings.get("compose_profile", "")
         self.auto_refresh_secs = settings["auto_refresh_secs"]
         self.max_log_lines = settings.get("max_log_lines", self.max_log_lines)
 
@@ -507,6 +514,8 @@ class MainWindow(QMainWindow):
             self.remote_combo.setCurrentText(self.git_remote)
         if hasattr(self, "compose_files_edit"):
             self.compose_files_edit.setText(";".join(self.compose_files))
+        if hasattr(self, "compose_profile_edit"):
+            self.compose_profile_edit.setText(self.compose_profile)
         if hasattr(self, "refresh_spin"):
             self.refresh_spin.setValue(self.auto_refresh_secs)
         if hasattr(self, "logs_tab"):
@@ -695,6 +704,11 @@ class MainWindow(QMainWindow):
         log_path = paths[0]
         git_remote = self.remote_combo.currentText() if hasattr(self, "remote_combo") else self.git_remote
         compose_text = self.compose_files_edit.text() if hasattr(self, "compose_files_edit") else ";".join(self.compose_files)
+        compose_profile = (
+            self.compose_profile_edit.text()
+            if hasattr(self, "compose_profile_edit")
+            else self.compose_profile
+        )
         auto_refresh_secs = self.refresh_spin.value() if hasattr(self, "refresh_spin") else self.auto_refresh_secs
         theme = self.theme_combo.currentText().lower() if hasattr(self, "theme_combo") else self.theme
 
@@ -736,6 +750,7 @@ class MainWindow(QMainWindow):
         self.log_paths = paths
         self.git_remote = git_remote
         self.compose_files = [p.strip() for p in compose_text.split(";") if p.strip()]
+        self.compose_profile = compose_profile.strip()
         self.auto_refresh_secs = int(auto_refresh_secs)
         self.theme = theme
         self.max_log_lines = int(getattr(self, "max_log_lines", MAX_LOG_LINES))
@@ -753,6 +768,7 @@ class MainWindow(QMainWindow):
             "log_paths": paths,
             "git_remote": git_remote,
             "compose_files": self.compose_files,
+            "compose_profile": self.compose_profile,
             "auto_refresh_secs": self.auto_refresh_secs,
             "max_log_lines": self.max_log_lines,
         }

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -87,6 +87,9 @@ class SettingsTab(QWidget):
         self.compose_label = QLabel("Compose Files:")
         form.addRow(self.compose_label, self.compose_row)
 
+        self.compose_profile_edit = QLineEdit(self.main_window.compose_profile)
+        form.addRow("Compose Profile:", self.compose_profile_edit)
+
         self.remote_combo = QComboBox()
         remotes = self.main_window.git_tab.get_remotes()
         if remotes:
@@ -175,6 +178,7 @@ class SettingsTab(QWidget):
         self.main_window.log_path_edit = self.log_path_edit
         self.main_window.remote_combo = self.remote_combo
         self.main_window.compose_files_edit = self.compose_files_edit
+        self.main_window.compose_profile_edit = self.compose_profile_edit
         self.main_window.refresh_spin = self.refresh_spin
         self.main_window.theme_combo = self.theme_combo
 
@@ -197,6 +201,7 @@ class SettingsTab(QWidget):
         self.docker_checkbox.toggled.connect(self.main_window.mark_settings_dirty)
         self.refresh_spin.valueChanged.connect(self.main_window.mark_settings_dirty)
         self.theme_combo.currentTextChanged.connect(self.main_window.mark_settings_dirty)
+        self.compose_profile_edit.textChanged.connect(self.main_window.mark_settings_dirty)
 
     def _wrap(self, child):
         """Return a QWidget containing the given layout or widget."""
@@ -269,6 +274,7 @@ class SettingsTab(QWidget):
         self.compose_browse_btn.setEnabled(checked)
         self.compose_row.setEnabled(checked)
         self.compose_label.setEnabled(checked)
+        self.compose_profile_edit.setEnabled(checked)
         if hasattr(self.main_window, "docker_index"):
             self.main_window.tabs.setTabVisible(self.main_window.docker_index, checked)
             self.main_window.tabs.setTabEnabled(self.main_window.docker_index, checked)

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -170,6 +170,36 @@ class TestMainWindow:
             "-d",
         ]
 
+    def test_start_project_includes_compose_profile(self, tmp_path: Path, main_window, monkeypatch):
+        main_window.project_path = str(tmp_path)
+        (tmp_path / "public").mkdir()
+
+        main_window.use_docker = True
+        main_window.compose_profile = "dev"
+
+        captured = {}
+
+        def fake_run(cmd, capture_output=True, text=True, cwd=None):
+            captured["cmd"] = cmd
+            class Result:
+                stdout = ""
+                stderr = ""
+            return Result()
+
+        monkeypatch.setattr(main_window.executor, "submit", lambda fn: fn(), raising=True)
+        monkeypatch.setattr(subprocess, "run", fake_run, raising=True)
+
+        main_window.start_project()
+
+        assert captured["cmd"] == [
+            "docker",
+            "compose",
+            "--profile",
+            "dev",
+            "up",
+            "-d",
+        ]
+
     def test_stop_project_uses_docker_compose_down(self, main_window, monkeypatch):
         main_window.use_docker = True
 
@@ -214,6 +244,32 @@ class TestMainWindow:
             "a.yml",
             "-f",
             "b.yml",
+            "down",
+        ]
+
+    def test_stop_project_includes_compose_profile(self, main_window, monkeypatch):
+        main_window.use_docker = True
+        main_window.compose_profile = "dev"
+
+        captured = {}
+
+        def fake_run(cmd, capture_output=True, text=True, cwd=None):
+            captured["cmd"] = cmd
+            class Result:
+                stdout = ""
+                stderr = ""
+            return Result()
+
+        monkeypatch.setattr(main_window.executor, "submit", lambda fn: fn(), raising=True)
+        monkeypatch.setattr(subprocess, "run", fake_run, raising=True)
+
+        main_window.stop_project()
+
+        assert captured["cmd"] == [
+            "docker",
+            "compose",
+            "--profile",
+            "dev",
             "down",
         ]
 
@@ -320,6 +376,33 @@ class TestMainWindow:
             "a.yml",
             "-f",
             "b.yml",
+            "exec",
+            "-T",
+            main_window.php_service,
+        ]
+
+    def test_run_command_adds_compose_profile(self, main_window, monkeypatch):
+        main_window.use_docker = True
+        main_window.compose_profile = "dev"
+        captured = {}
+
+        def fake_run(cmd, capture_output=True, text=True, cwd=None):
+            captured["cmd"] = cmd
+            class Result:
+                stdout = ""
+                stderr = ""
+            return Result()
+
+        monkeypatch.setattr(subprocess, "run", fake_run, raising=True)
+        monkeypatch.setattr(main_window.executor, "submit", lambda fn: fn(), raising=True)
+
+        main_window.run_command(["php", "-v"])
+
+        assert captured["cmd"][:7] == [
+            "docker",
+            "compose",
+            "--profile",
+            "dev",
             "exec",
             "-T",
             main_window.php_service,
@@ -883,3 +966,19 @@ class TestMainWindow:
 
         assert main_window.compose_files == ["a.yml", "b.yml"]
         assert saved["project_settings"]["/tmp"]["compose_files"] == ["a.yml", "b.yml"]
+
+    def test_save_settings_saves_compose_profile(self, main_window, monkeypatch):
+        main_window.project_combo.addItem("/tmp")
+        main_window.project_combo.setCurrentText("/tmp")
+        main_window.project_path = "/tmp"
+        main_window.docker_checkbox.setChecked(True)
+        main_window.compose_profile_edit.setText("dev")
+
+        monkeypatch.setattr(os.path, "isdir", lambda p: True, raising=True)
+        saved = {}
+        monkeypatch.setattr(mw_module, "save_config", lambda data: saved.update(data), raising=True)
+
+        main_window.save_settings()
+
+        assert main_window.compose_profile == "dev"
+        assert saved["project_settings"]["/tmp"]["compose_profile"] == "dev"

--- a/tests/test_settings_tab.py
+++ b/tests/test_settings_tab.py
@@ -11,6 +11,7 @@ class DummyMainWindow:
         self.php_service = "php"
         self.server_port = 8000
         self.compose_files = []
+        self.compose_profile = ""
         self.use_docker = False
         self.yii_template = "basic"
         self.log_path = ""


### PR DESCRIPTION
## Summary
- add `compose_profile` setting in configuration
- support compose profile in command prefix
- enable profile input in Settings tab
- test docker compose profile behavior
- document compose profile option

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`