### PR TITLE
Handle empty search query in LogsTab

### DIFF
--- a/fusor/tabs/logs_tab.py
+++ b/fusor/tabs/logs_tab.py
@@ -129,6 +129,9 @@ class LogsTab(QWidget):
     def search_logs(self):
         text = self.search_edit.text().strip()
         if not text:
+            self.log_view.setExtraSelections([])
+            self.prev_btn.setEnabled(False)
+            self.next_btn.setEnabled(False)
             return
 
         content = self.log_view.toPlainText()

--- a/tests/test_logs_tab.py
+++ b/tests/test_logs_tab.py
@@ -75,6 +75,31 @@ def test_search_cycle_multiple_matches(qtbot):
     qtbot.wait(10)
     assert current_start() == 16
 
+
+def test_search_empty_clears_highlighting(qtbot):
+    main = DummyMainWindow()
+    tab = LogsTab(main)
+    qtbot.addWidget(tab)
+
+    text = "foo bar foo"
+    tab.log_view.setPlainText(text)
+
+    tab.search_edit.setText("foo")
+    qtbot.mouseClick(tab.search_btn, Qt.MouseButton.LeftButton)
+    qtbot.wait(10)
+
+    assert tab.log_view.extraSelections()
+    assert tab.next_btn.isEnabled()
+    assert tab.prev_btn.isEnabled()
+
+    tab.search_edit.setText("")
+    qtbot.mouseClick(tab.search_btn, Qt.MouseButton.LeftButton)
+    qtbot.wait(10)
+
+    assert tab.log_view.extraSelections() == []
+    assert not tab.next_btn.isEnabled()
+    assert not tab.prev_btn.isEnabled()
+
 def test_auto_refresh_truncates_large_file(tmp_path, qtbot, monkeypatch):
     from PyQt6.QtCore import QTimer
     from fusor import main_window as mw_module


### PR DESCRIPTION
## Summary
- clear results in `LogsTab.search_logs` when the query is empty
- test clearing behaviour when search input is blank

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687982a239d08322862107b33ddedec7