### PR TITLE
Use env APP_NAME for window title

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ pip install -r requirements.txt
 python -m fusor
 ```
 
+Set the `APP_NAME` environment variable to customize the window title:
+
+```bash
+APP_NAME="My App" python -m fusor
+```
+
 ---
 
 ## 🐳 Docker Mode

--- a/fusor/__init__.py
+++ b/fusor/__init__.py
@@ -1,4 +1,6 @@
-APP_NAME = "Fusor"
+import os
+
+APP_NAME = os.getenv("APP_NAME", "Fusor")
 __version__ = "0.2.5"
 DESCRIPTION = (
     "A minimal PyQt6 application with helper tools for PHP development."

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -19,6 +19,7 @@ from PyQt6.QtWidgets import (
 )
 from PyQt6.QtCore import QTimer
 from .icons import get_icon
+from . import APP_NAME
 
 from .config import (
     load_config,
@@ -247,7 +248,7 @@ def apply_theme(widget: QMainWindow, theme: str) -> None:
 class MainWindow(QMainWindow):
     def __init__(self):
         super().__init__()
-        self.setWindowTitle("Fusor – PHP QA Toolbox")
+        self.setWindowTitle(f"{APP_NAME} – PHP QA Toolbox")
         self.resize(1024, 768)
         self.theme = "dark"
 

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -9,6 +9,7 @@ from PyQt6.QtCore import QTimer, Qt
 
 import fusor.main_window as mw_module
 from fusor.main_window import MainWindow
+from fusor import APP_NAME
 from PyQt6.QtWidgets import QMainWindow, QPushButton, QMessageBox
 from fusor.tabs.git_tab import GitTab
 
@@ -536,7 +537,7 @@ class TestMainWindow:
 
         qtbot.mouseClick(main_window.help_button, Qt.MouseButton.LeftButton)
 
-        assert shown == ["About Fusor"]
+        assert shown == [f"About {APP_NAME}"]
 
     def test_remove_project_updates_config(self, qtbot, monkeypatch):
         monkeypatch.setattr(QTimer, "singleShot", lambda *a, **k: None, raising=True)


### PR DESCRIPTION
## Summary
- import `APP_NAME` into `MainWindow` and use it for the title
- allow overriding `APP_NAME` via environment variable
- update tests to use `APP_NAME`
- document the `APP_NAME` environment variable in the README

## Testing
- `ruff check .`
- `mypy fusor`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687990a4261083228bb95573506820b9