### PR TITLE
Silence console output

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -286,8 +286,12 @@ class MainWindow(QMainWindow):
         self.project_running = False
         self.settings_dirty = False
 
-        # Redirect stdout to the output view
-        self._stdout_logger = QTextEditLogger(self.output_view, sys.stdout)
+        # Redirect stdout to the output view only
+        self._stdout_logger = QTextEditLogger(
+            self.output_view,
+            sys.stdout,
+            echo=False,
+        )
         sys.stdout = self._stdout_logger
 
         # Directory containing project files and PHP executable path

--- a/fusor/qtextedit_logger.py
+++ b/fusor/qtextedit_logger.py
@@ -2,9 +2,10 @@ from PyQt6.QtCore import QMetaObject, Qt, Q_ARG
 
 
 class QTextEditLogger:
-    def __init__(self, text_edit, original_stdout):
+    def __init__(self, text_edit, original_stdout, echo=True):
         self.text_edit = text_edit
         self.original_stdout = original_stdout
+        self.echo = echo
 
     def write(self, msg):
         if msg.rstrip():
@@ -14,7 +15,9 @@ class QTextEditLogger:
                 Qt.ConnectionType.QueuedConnection,
                 Q_ARG(str, msg.rstrip()),
             )
-        self.original_stdout.write(msg)
+        if self.echo:
+            self.original_stdout.write(msg)
 
     def flush(self):
-        self.original_stdout.flush()
+        if self.echo:
+            self.original_stdout.flush()


### PR DESCRIPTION
## Summary
- silence console output by default
- redirect stdout to GUI only

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687994f421bc83229e324e5b11fb00b5