### PR TITLE
Add git status and diff actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Fusor aims to **simplify routine PHP project operations** via a user-friendly vi
 | Tab          | Description                                                                       |
 | ------------ | --------------------------------------------------------------------------------- |
 | **Project**  | Start/stop server, run PHPUnit, Composer install/update                           |
-| **Git**      | Switch branches, pull, hard reset, stash changes                                  |
+| **Git**      | Switch branches, view status or diff, pull, hard reset, stash changes             |
 | **Database** | Dump or restore SQL, run migrations, seed data                                    |
 | **Docker**   | Build, pull, restart services, inspect containers _(visible only in Docker mode)_ |
 | **Logs**     | View logs with optional auto-refresh                                              |

--- a/fusor/tabs/git_tab.py
+++ b/fusor/tabs/git_tab.py
@@ -101,6 +101,16 @@ class GitTab(QWidget):
             self.stash,
             icon="document-save",
         )
+        status_btn = self._btn(
+            "Status",
+            self.show_status,
+            icon="dialog-information",
+        )
+        diff_btn = self._btn(
+            "Diff",
+            self.show_diff,
+            icon="document-diff",
+        )
         view_log_btn = self._btn(
             "View Log",
             self.view_log,
@@ -111,6 +121,8 @@ class GitTab(QWidget):
         actions_layout.addWidget(push_btn)
         actions_layout.addWidget(reset_btn)
         actions_layout.addWidget(stash_btn)
+        actions_layout.addWidget(status_btn)
+        actions_layout.addWidget(diff_btn)
         actions_layout.addWidget(view_log_btn)
 
         actions_group.setLayout(actions_layout)
@@ -226,6 +238,14 @@ class GitTab(QWidget):
     def view_log(self):
         """Show recent git log entries."""
         self.run_git_command("log", "-n", "20", "--oneline")
+
+    def show_status(self):
+        """Display git status."""
+        self.run_git_command("status")
+
+    def show_diff(self):
+        """Display git diff."""
+        self.run_git_command("diff")
 
     def create_branch(self):
         branch = self.branch_name_edit.text().strip()

--- a/tests/test_git_tab.py
+++ b/tests/test_git_tab.py
@@ -211,3 +211,51 @@ def test_view_log_button_runs_log(monkeypatch, qtbot):
     qtbot.mouseClick(view_btn, Qt.MouseButton.LeftButton)
 
     assert called["args"] == ("log", "-n", "20", "--oneline")
+
+
+def test_status_button_runs_status(monkeypatch, qtbot):
+    main = DummyMainWindow()
+    tab = GitTab(main)
+    qtbot.addWidget(tab)
+
+    called = {}
+
+    def fake_run_git_command(*args):
+        called["args"] = args
+
+    monkeypatch.setattr(tab, "run_git_command", fake_run_git_command, raising=True)
+
+    status_btn: QPushButton | None = None
+    for btn in tab.findChildren(QPushButton):
+        if btn.text() == "Status":
+            status_btn = btn
+            break
+    assert status_btn is not None
+
+    qtbot.mouseClick(status_btn, Qt.MouseButton.LeftButton)
+
+    assert called["args"] == ("status",)
+
+
+def test_diff_button_runs_diff(monkeypatch, qtbot):
+    main = DummyMainWindow()
+    tab = GitTab(main)
+    qtbot.addWidget(tab)
+
+    called = {}
+
+    def fake_run_git_command(*args):
+        called["args"] = args
+
+    monkeypatch.setattr(tab, "run_git_command", fake_run_git_command, raising=True)
+
+    diff_btn: QPushButton | None = None
+    for btn in tab.findChildren(QPushButton):
+        if btn.text() == "Diff":
+            diff_btn = btn
+            break
+    assert diff_btn is not None
+
+    qtbot.mouseClick(diff_btn, Qt.MouseButton.LeftButton)
+
+    assert called["args"] == ("diff",)


### PR DESCRIPTION
## Summary
- add Status and Diff buttons to Git tab
- document new Git actions in README
- test Git tab Status and Diff buttons

## Testing
- `pytest -q`