### PR TITLE
Add welcome modal for projects

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -29,6 +29,7 @@ from .config import (
     DEFAULT_MAX_LOG_LINES,
 )
 from .qtextedit_logger import QTextEditLogger
+from .welcome_dialog import WelcomeDialog
 
 from .tabs.project_tab import ProjectTab
 from .tabs.git_tab import GitTab
@@ -374,7 +375,10 @@ class MainWindow(QMainWindow):
         if self.project_path:
             self.git_tab.load_branches()
         else:
-            QTimer.singleShot(0, self.choose_project)
+            if not self.projects:
+                QTimer.singleShot(0, self.show_welcome_dialog)
+            else:
+                QTimer.singleShot(0, self.choose_project)
 
         if (
             hasattr(self, "_geom_size")
@@ -579,7 +583,7 @@ class MainWindow(QMainWindow):
     def ensure_project_path(self):
         if not self.project_path:
             print("Project path not set")
-            self.close()
+            self.show_welcome_dialog()
             return False
         return True
 
@@ -623,7 +627,7 @@ class MainWindow(QMainWindow):
 
     def choose_project(self):
         if not self.projects:
-            self.add_project()
+            self.show_welcome_dialog()
             return
         names = [p["name"] for p in self.projects]
         current_index = next(
@@ -643,6 +647,10 @@ class MainWindow(QMainWindow):
                 if p["name"] == name:
                     self.set_current_project(p["path"])
                     break
+
+    def show_welcome_dialog(self):
+        dlg = WelcomeDialog(self)
+        dlg.exec()
 
     def current_framework(self):
         return (

--- a/fusor/welcome_dialog.py
+++ b/fusor/welcome_dialog.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+from PyQt6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QLabel,
+    QPushButton,
+    QFileDialog,
+    QInputDialog,
+    QMessageBox,
+)
+
+from . import APP_NAME
+
+
+class WelcomeDialog(QDialog):
+    """Dialog presented when no projects are configured."""
+
+    def __init__(self, main_window) -> None:
+        super().__init__(main_window)
+        self.main_window = main_window
+        self.setWindowTitle(f"Welcome to {APP_NAME}")
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Select a project to get started:"))
+
+        add_btn = QPushButton("Add Project")
+        add_btn.clicked.connect(self.add_project)
+        layout.addWidget(add_btn)
+
+        create_btn = QPushButton("Create Project")
+        create_btn.clicked.connect(self.create_project)
+        layout.addWidget(create_btn)
+
+        clone_btn = QPushButton("Clone from Git")
+        clone_btn.clicked.connect(self.clone_project)
+        layout.addWidget(clone_btn)
+
+    # ------------------------------------------------------------------
+    def add_project(self) -> None:
+        path = QFileDialog.getExistingDirectory(self, "Select Project Path")
+        if path:
+            self.main_window.set_current_project(path)
+            self.main_window.save_settings()
+            self.accept()
+
+    def create_project(self) -> None:  # pragma: no cover - not implemented yet
+        QMessageBox.information(self, "Create Project", "Not implemented yet")
+
+    def clone_project(self) -> None:
+        url, ok = QInputDialog.getText(self, "Clone from Git", "Repository URL:")
+        if not ok or not url:
+            return
+
+        dest_base = QFileDialog.getExistingDirectory(self, "Select Destination")
+        if not dest_base:
+            return
+
+        name, ok = QInputDialog.getText(
+            self, "Clone from Git", "Project Directory Name:"
+        )
+        if not ok or not name:
+            return
+
+        dest = Path(dest_base) / name
+        if dest.exists():
+            QMessageBox.warning(self, "Clone", "Destination already exists")
+            return
+
+        try:
+            check = subprocess.run(
+                ["git", "ls-remote", url], capture_output=True, text=True
+            )
+            if check.returncode != 0:
+                QMessageBox.warning(self, "Clone", "Invalid repository URL")
+                return
+        except FileNotFoundError:  # pragma: no cover
+            QMessageBox.warning(self, "Clone", "git executable not found")
+            return
+
+        subprocess.run(["git", "clone", url, str(dest)])
+        self.main_window.set_current_project(str(dest))
+        self.main_window.save_settings()
+        self.accept()

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -50,6 +50,14 @@ class TestMainWindow:
         closed = []
         monkeypatch.setattr(main_window, "close", lambda: closed.append(True), raising=True)
 
+        shown = []
+
+        class DummyDlg:
+            def exec(self):
+                shown.append(True)
+
+        monkeypatch.setattr(mw_module, "WelcomeDialog", lambda *a, **k: DummyDlg(), raising=True)
+
         def forbid(*_a, **_kw):
             raise AssertionError("unexpected FS access")
 
@@ -58,7 +66,8 @@ class TestMainWindow:
 
         main_window.refresh_logs()
 
-        assert closed == [True]
+        assert closed == []
+        assert shown == [True]
         assert main_window.log_view.text is None
 
     def test_start_project_uses_configured_php(self, tmp_path: Path, main_window, monkeypatch):


### PR DESCRIPTION
## Summary
- introduce `WelcomeDialog` with options to add or clone a project
- show the new welcome dialog on startup when no project exists
- prevent the app from closing when no project is configured
- update tests for the new behaviour

## Testing
- `ruff check .`
- `flake8`
- `mypy fusor`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ba69c43608322b524cf7a2dbf06e9