### PR TITLE
Enable log path settings for Yii and Symfony

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -656,7 +656,11 @@ class MainWindow(QMainWindow):
             else "None"
         )
 
-    def default_log_paths(self, framework: str | None = None, template: str | None = None) -> list[str]:
+    def default_log_paths(
+        self,
+        framework: str | None = None,
+        template: str | None = None,
+    ) -> list[str]:
         """Return default log file paths for the given framework."""
         if framework is None:
             framework = self.framework_choice

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -437,10 +437,8 @@ class MainWindow(QMainWindow):
             legacy = settings.get("log_path", data.get("log_path"))
             if legacy:
                 self.log_paths = [legacy]
-            elif self.framework_choice == "Laravel":
-                self.log_paths = [str(Path("storage") / "logs" / "laravel.log")]
             else:
-                self.log_paths = []
+                self.log_paths = self.default_log_paths(self.framework_choice)
         self.git_remote = settings.get(
             "git_remote", data.get("git_remote", self.git_remote)
         )
@@ -513,10 +511,8 @@ class MainWindow(QMainWindow):
             legacy = settings.get("log_path")
             if legacy:
                 self.log_paths = [legacy]
-            elif self.framework_choice == "Laravel":
-                self.log_paths = [str(Path("storage") / "logs" / "laravel.log")]
             else:
-                self.log_paths = []
+                self.log_paths = self.default_log_paths(self.framework_choice)
         self.git_remote = settings["git_remote"]
         self.compose_files = settings["compose_files"]
         self.compose_profile = settings.get("compose_profile", "")
@@ -660,6 +656,24 @@ class MainWindow(QMainWindow):
             else "None"
         )
 
+    def default_log_paths(self, framework: str | None = None, template: str | None = None) -> list[str]:
+        """Return default log file paths for the given framework."""
+        if framework is None:
+            framework = self.framework_choice
+        if framework == "Laravel":
+            return [str(Path("storage") / "logs" / "laravel.log")]
+        if framework == "Symfony":
+            return [str(Path("var") / "log" / "dev.log")]
+        if framework == "Yii":
+            tmpl = template if template is not None else self.yii_template
+            if tmpl == "advanced":
+                return [
+                    str(Path(part) / "runtime" / "logs" / "app.log")
+                    for part in ["frontend", "backend", "console"]
+                ]
+            return [str(Path("runtime") / "log" / "app.log")]
+        return []
+
     def _tail_file(self, path: Path, lines: int) -> str:
         """Return the last ``lines`` lines from ``path``."""
         try:
@@ -688,7 +702,7 @@ class MainWindow(QMainWindow):
         framework = self.current_framework()
         log_contents = ""
         if framework == "Laravel":
-            log_files = self.log_paths
+            log_files = self.log_paths or self.default_log_paths("Laravel")
             selector = getattr(self.logs_tab, "log_selector", None)
             if selector and selector.currentData():
                 log_files = [selector.currentData()]
@@ -705,18 +719,29 @@ class MainWindow(QMainWindow):
                 heading = f"=== {file} ===" if len(log_files) > 1 else ""
                 parts.append(f"{heading}\n{content}" if heading else content)
             log_contents = "\n\n".join(parts)
-        elif framework == "Yii":
-            if self.yii_template == "advanced":
-                log_files = [
-                    Path(self.project_path) / part / "runtime" / "logs" / "app.log"
-                    for part in ["frontend", "backend", "console"]
-                ]
-            else:
-                log_files = [Path(self.project_path) / "runtime" / "log" / "app.log"]
+        elif framework == "Symfony":
+            log_files = self.log_paths or self.default_log_paths("Symfony")
 
             parts: list[str] = []
             for file in log_files:
                 path = Path(file)
+                if not path.is_absolute():
+                    path = Path(self.project_path) / path
+                if path.exists():
+                    content = self._tail_file(path, self.max_log_lines)
+                else:
+                    content = f"Log file not found: {path}"
+                heading = f"=== {file} ===" if len(log_files) > 1 else ""
+                parts.append(f"{heading}\n{content}" if heading else content)
+            log_contents = "\n\n".join(parts)
+        elif framework == "Yii":
+            log_files = self.log_paths or self.default_log_paths("Yii")
+
+            parts: list[str] = []
+            for file in log_files:
+                path = Path(file)
+                if not path.is_absolute():
+                    path = Path(self.project_path) / path
                 if path.exists():
                     content = self._tail_file(path, self.max_log_lines)
                 else:

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -231,6 +231,9 @@ class SettingsTab(QWidget):
         self.yii_template_combo.currentTextChanged.connect(
             self.main_window.mark_settings_dirty
         )
+        self.yii_template_combo.currentTextChanged.connect(
+            self.on_yii_template_changed
+        )
         self.docker_checkbox.toggled.connect(self.main_window.mark_settings_dirty)
         self.refresh_spin.valueChanged.connect(self.main_window.mark_settings_dirty)
         self.theme_combo.currentTextChanged.connect(
@@ -415,10 +418,17 @@ class SettingsTab(QWidget):
         self.yii_template_row.setVisible(visible)
         self.yii_template_label.setVisible(visible)
 
-        log_visible = text == "Laravel"
+        log_visible = text in ["Laravel", "Yii", "Symfony"]
         self.log_paths_container.setVisible(log_visible)
         self.log_path_label.setVisible(log_visible)
         self.add_log_btn.setVisible(log_visible)
+        if log_visible:
+            template = self.yii_template_combo.currentText()
+            paths = self.main_window.default_log_paths(text, template)
+            self.set_log_paths(paths or [""])
+            self.main_window.log_paths = paths
+            if hasattr(self.main_window, "logs_tab"):
+                self.main_window.logs_tab.set_log_paths(paths)
 
         for attr in ["database_tab", "laravel_tab", "symfony_tab", "yii_tab"]:
             tab = getattr(self.main_window, attr, None)
@@ -436,3 +446,12 @@ class SettingsTab(QWidget):
                 show = text == fw
                 self.main_window.tabs.setTabVisible(idx, show)
                 self.main_window.tabs.setTabEnabled(idx, show)
+
+    def on_yii_template_changed(self, text: str) -> None:
+        if self.framework_combo.currentText() != "Yii":
+            return
+        paths = self.main_window.default_log_paths("Yii", text)
+        self.set_log_paths(paths or [""])
+        self.main_window.log_paths = paths
+        if hasattr(self.main_window, "logs_tab"):
+            self.main_window.logs_tab.set_log_paths(paths)

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -503,6 +503,30 @@ class TestMainWindow:
         assert not main_window.settings_tab.log_paths_container.isHidden()
         assert not main_window.settings_tab.log_path_label.isHidden()
 
+        main_window.framework_combo.setCurrentText("Symfony")
+        qtbot.wait(10)
+        assert not main_window.settings_tab.log_paths_container.isHidden()
+        assert not main_window.settings_tab.log_path_label.isHidden()
+
+        main_window.framework_combo.setCurrentText("Yii")
+        qtbot.wait(10)
+        assert not main_window.settings_tab.log_paths_container.isHidden()
+        assert not main_window.settings_tab.log_path_label.isHidden()
+
+    def test_default_log_paths_per_framework(self, main_window, qtbot):
+        main_window.framework_combo.setCurrentText("Laravel")
+        qtbot.wait(10)
+        assert main_window.settings_tab.log_path_edits[0].text() == str(Path("storage") / "logs" / "laravel.log")
+
+        main_window.framework_combo.setCurrentText("Symfony")
+        qtbot.wait(10)
+        assert main_window.settings_tab.log_path_edits[0].text() == str(Path("var") / "log" / "dev.log")
+
+        main_window.framework_combo.setCurrentText("Yii")
+        main_window.yii_template_combo.setCurrentText("basic")
+        qtbot.wait(10)
+        assert main_window.settings_tab.log_path_edits[0].text() == str(Path("runtime") / "log" / "app.log")
+
     def test_settings_unsaved_indicator(self, main_window, qtbot):
         idx = main_window.tabs.indexOf(main_window.settings_tab)
         assert main_window.tabs.tabText(idx) == "Settings"

--- a/tests/test_settings_tab.py
+++ b/tests/test_settings_tab.py
@@ -22,6 +22,9 @@ class DummyMainWindow:
         self.database_tab = type("D", (), {"on_framework_changed": lambda self, t: None})()
         self.mark_settings_dirty = lambda *a, **k: None
 
+    def default_log_paths(self, framework: str, template: str | None = None):
+        return []
+
     def set_current_project(self, path: str):
         self.project_path = path
 


### PR DESCRIPTION
## Summary
- show log path fields when framework is Laravel, Symfony or Yii
- update default log path depending on selected framework
- refresh logs from configured paths for Symfony and Yii
- handle Yii template changes
- update tests for new behaviour

## Testing
- `pytest -q`