### PR TITLE
Add PHP tools section to Project tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Fusor aims to **simplify routine PHP project operations** via a user-friendly vi
 
 | Tab          | Description                                                                       |
 | ------------ | --------------------------------------------------------------------------------- |
-| **Project**  | Start/stop server, run PHPUnit, Composer install/update                           |
+| **Project**  | Start/stop server, Composer install/update, PHP tools (PHPUnit, Rector, CS-Fixer) |
 | **Git**      | Switch branches, view status or diff, pull, hard reset, stash changes             |
 | **Database** | Dump or restore SQL, run migrations, seed data                                    |
 | **Docker**   | Build, pull, restart services, inspect containers _(visible only in Docker mode)_ |

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -555,6 +555,9 @@ class MainWindow(QMainWindow):
 
         self.mark_settings_saved()
 
+        if hasattr(self, "project_tab") and hasattr(self.project_tab, "update_php_tools"):
+            self.project_tab.update_php_tools()
+
     def run_command(self, command):
         if self.use_docker:
             if len(command) >= 2 and command[0] == "docker" and command[1] == "compose":

--- a/tests/test_project_tab.py
+++ b/tests/test_project_tab.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import subprocess
+import json
 
 from fusor.tabs.project_tab import ProjectTab
 
@@ -119,3 +120,31 @@ def test_open_explorer_linux_fallback(monkeypatch, qtbot):
     monkeypatch.setattr(os, "name", "posix", raising=False)
     tab.open_explorer()
     assert cmds == [["xdg-open", main.project_path], ["gio", "open", main.project_path]]
+
+
+def test_update_php_tools_enable_buttons(tmp_path, qtbot):
+    data = {
+        "require-dev": {
+            "phpunit/phpunit": "*",
+            "rector/rector": "*",
+        }
+    }
+    (tmp_path / "composer.json").write_text(json.dumps(data))
+
+    tab, main = make_tab(qtbot)
+    main.project_path = str(tmp_path)
+    tab.update_php_tools()
+
+    assert tab.phpunit_btn.isEnabled()
+    assert tab.rector_btn.isEnabled()
+    assert not tab.csfixer_btn.isEnabled()
+
+
+def test_update_php_tools_disable_without_composer(tmp_path, qtbot):
+    tab, main = make_tab(qtbot)
+    main.project_path = str(tmp_path)
+    tab.update_php_tools()
+
+    assert not tab.phpunit_btn.isEnabled()
+    assert not tab.rector_btn.isEnabled()
+    assert not tab.csfixer_btn.isEnabled()


### PR DESCRIPTION
## Summary
- organize Project tab with a dedicated PHP Tools group
- add Rector and CS-Fixer buttons
- disable PHP tool buttons when packages are absent in `composer.json`
- update settings to refresh PHP tool states on project change
- document PHP tools in README
- test composer package detection logic

## Testing
- `pytest -q`