### PR TITLE
Refactor Settings layout

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -544,7 +544,9 @@ class MainWindow(QMainWindow):
             if self.git_remote and self.git_remote not in remotes:
                 self.remote_combo.addItem(self.git_remote)
             self.remote_combo.setCurrentText(self.git_remote)
-        if hasattr(self, "compose_files_edit"):
+        if hasattr(self, "settings_tab") and hasattr(self.settings_tab, "set_compose_files"):
+            self.settings_tab.set_compose_files(self.compose_files)
+        elif hasattr(self, "compose_files_edit"):
             self.compose_files_edit.setText(";".join(self.compose_files))
         if hasattr(self, "compose_profile_edit"):
             self.compose_profile_edit.setText(self.compose_profile)
@@ -806,11 +808,15 @@ class MainWindow(QMainWindow):
             if hasattr(self, "remote_combo")
             else self.git_remote
         )
-        compose_text = (
-            self.compose_files_edit.text()
-            if hasattr(self, "compose_files_edit")
-            else ";".join(self.compose_files)
-        )
+        if hasattr(self, "settings_tab") and hasattr(self.settings_tab, "compose_file_edits"):
+            compose_files = [e.text().strip() for e in self.settings_tab.compose_file_edits if e.text().strip()]
+        else:
+            compose_text = (
+                self.compose_files_edit.text()
+                if hasattr(self, "compose_files_edit")
+                else ";".join(self.compose_files)
+            )
+            compose_files = [p.strip() for p in compose_text.split(";") if p.strip()]
         compose_profile = (
             self.compose_profile_edit.text()
             if hasattr(self, "compose_profile_edit")
@@ -887,7 +893,7 @@ class MainWindow(QMainWindow):
         self.yii_template = yii_template
         self.log_paths = paths
         self.git_remote = git_remote
-        self.compose_files = [p.strip() for p in compose_text.split(";") if p.strip()]
+        self.compose_files = compose_files
         self.compose_profile = compose_profile.strip()
         self.auto_refresh_secs = int(auto_refresh_secs)
         self.theme = theme

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -544,7 +544,10 @@ class MainWindow(QMainWindow):
             if self.git_remote and self.git_remote not in remotes:
                 self.remote_combo.addItem(self.git_remote)
             self.remote_combo.setCurrentText(self.git_remote)
-        if hasattr(self, "settings_tab") and hasattr(self.settings_tab, "set_compose_files"):
+        if (
+            hasattr(self, "settings_tab")
+            and hasattr(self.settings_tab, "set_compose_files")
+        ):
             self.settings_tab.set_compose_files(self.compose_files)
         elif hasattr(self, "compose_files_edit"):
             self.compose_files_edit.setText(";".join(self.compose_files))
@@ -557,7 +560,10 @@ class MainWindow(QMainWindow):
 
         self.mark_settings_saved()
 
-        if hasattr(self, "project_tab") and hasattr(self.project_tab, "update_php_tools"):
+        if (
+            hasattr(self, "project_tab")
+            and hasattr(self.project_tab, "update_php_tools")
+        ):
             self.project_tab.update_php_tools()
 
     def run_command(self, command):
@@ -808,8 +814,15 @@ class MainWindow(QMainWindow):
             if hasattr(self, "remote_combo")
             else self.git_remote
         )
-        if hasattr(self, "settings_tab") and hasattr(self.settings_tab, "compose_file_edits"):
-            compose_files = [e.text().strip() for e in self.settings_tab.compose_file_edits if e.text().strip()]
+        if (
+            hasattr(self, "settings_tab")
+            and hasattr(self.settings_tab, "compose_file_edits")
+        ):
+            compose_files = [
+                e.text().strip()
+                for e in self.settings_tab.compose_file_edits
+                if e.text().strip()
+            ]
         else:
             compose_text = (
                 self.compose_files_edit.text()

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -591,7 +591,7 @@ class MainWindow(QMainWindow):
     def ensure_project_path(self):
         if not self.project_path:
             print("Project path not set")
-            self.show_welcome_dialog()
+            self.show_welcome_dialog(exit_if_none=False)
             return False
         return True
 
@@ -655,10 +655,10 @@ class MainWindow(QMainWindow):
                     self.set_current_project(p["path"])
                     break
 
-    def show_welcome_dialog(self):
+    def show_welcome_dialog(self, exit_if_none: bool = True):
         dlg = WelcomeDialog(self)
         dlg.exec()
-        if not self.projects:
+        if exit_if_none and not self.projects:
             self.close()
 
     def current_framework(self):

--- a/fusor/tabs/project_tab.py
+++ b/fusor/tabs/project_tab.py
@@ -78,12 +78,19 @@ class ProjectTab(QWidget):
         )
         self.rector_btn = self._btn(
             "Run Rector",
-            lambda: main_window.run_command([main_window.php_path, str(Path("vendor") / "bin" / "rector")]),
+            lambda: main_window.run_command(
+                [main_window.php_path, str(Path("vendor") / "bin" / "rector")]
+            ),
             icon="system-run",
         )
         self.csfixer_btn = self._btn(
             "Run PHP CS-Fixer",
-            lambda: main_window.run_command([main_window.php_path, str(Path("vendor") / "bin" / "php-cs-fixer")]),
+            lambda: main_window.run_command(
+                [
+                    main_window.php_path,
+                    str(Path("vendor") / "bin" / "php-cs-fixer"),
+                ]
+            ),
             icon="system-run",
         )
 

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -940,7 +940,9 @@ class TestMainWindow:
         main_window.project_combo.setCurrentText("/tmp")
         main_window.project_path = "/tmp"
         main_window.docker_checkbox.setChecked(True)
-        main_window.compose_files_edit.setText(" a.yml ; b.yml ;  ")
+        main_window.settings_tab.add_compose_btn.click()
+        main_window.settings_tab.compose_file_edits[0].setText(" a.yml ")
+        main_window.settings_tab.compose_file_edits[1].setText(" b.yml  ")
 
         monkeypatch.setattr(os.path, "isdir", lambda p: True, raising=True)
         saved = {}


### PR DESCRIPTION
## Summary
- allow keeping the main window open if no project is selected
- split big "Project Settings" group into smaller sections

## Testing
- `pytest -q`