### PR TITLE
Implement project creation

### DIFF
--- a/fusor/welcome_dialog.py
+++ b/fusor/welcome_dialog.py
@@ -82,14 +82,21 @@ class WelcomeDialog(QDialog):
 
         try:
             res = subprocess.run(
-                cmd, capture_output=True, text=True, cwd=dest if cmd[1] == "init" else None
+                cmd,
+                capture_output=True,
+                text=True,
+                cwd=dest if cmd[1] == "init" else None,
             )
         except FileNotFoundError:
             QMessageBox.warning(self, "Create Project", "composer executable not found")
             return
 
         if res.returncode != 0:
-            QMessageBox.warning(self, "Create Project", res.stderr or "Failed to create project")
+            QMessageBox.warning(
+                self,
+                "Create Project",
+                res.stderr or "Failed to create project",
+            )
             return
 
         self.main_window.set_current_project(str(dest))

--- a/fusor/welcome_dialog.py
+++ b/fusor/welcome_dialog.py
@@ -47,8 +47,54 @@ class WelcomeDialog(QDialog):
             self.main_window.save_settings()
             self.accept()
 
-    def create_project(self) -> None:  # pragma: no cover - not implemented yet
-        QMessageBox.information(self, "Create Project", "Not implemented yet")
+    def create_project(self) -> None:
+        dest_base = QFileDialog.getExistingDirectory(self, "Select Destination")
+        if not dest_base:
+            return
+
+        name, ok = QInputDialog.getText(
+            self, "Create Project", "Project Directory Name:"
+        )
+        if not ok or not name:
+            return
+
+        dest = Path(dest_base) / name
+        if dest.exists():
+            QMessageBox.warning(self, "Create Project", "Destination already exists")
+            return
+
+        fw = getattr(self.main_window, "framework_choice", "Laravel")
+        if fw == "Laravel":
+            cmd = ["composer", "create-project", "laravel/laravel", str(dest)]
+        elif fw == "Symfony":
+            cmd = ["composer", "create-project", "symfony/skeleton", str(dest)]
+        elif fw == "Yii":
+            template = getattr(self.main_window, "yii_template", "basic")
+            pkg = (
+                "yiisoft/yii2-app-basic"
+                if template == "basic"
+                else "yiisoft/yii2-app-advanced"
+            )
+            cmd = ["composer", "create-project", pkg, str(dest)]
+        else:
+            dest.mkdir(parents=True, exist_ok=True)
+            cmd = ["composer", "init", "-n"]
+
+        try:
+            res = subprocess.run(
+                cmd, capture_output=True, text=True, cwd=dest if cmd[1] == "init" else None
+            )
+        except FileNotFoundError:
+            QMessageBox.warning(self, "Create Project", "composer executable not found")
+            return
+
+        if res.returncode != 0:
+            QMessageBox.warning(self, "Create Project", res.stderr or "Failed to create project")
+            return
+
+        self.main_window.set_current_project(str(dest))
+        self.main_window.save_settings()
+        self.accept()
 
     def clone_project(self) -> None:
         url, ok = QInputDialog.getText(self, "Clone from Git", "Repository URL:")

--- a/tests/test_welcome_dialog.py
+++ b/tests/test_welcome_dialog.py
@@ -1,0 +1,75 @@
+import subprocess
+
+from fusor.welcome_dialog import WelcomeDialog
+from PyQt6.QtWidgets import QFileDialog, QInputDialog, QMessageBox, QWidget
+
+
+class DummyMainWindow(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.framework_choice = "Laravel"
+        self.yii_template = "basic"
+        self.saved = False
+        self.path = None
+
+    def set_current_project(self, path: str):
+        self.path = path
+
+    def save_settings(self):
+        self.saved = True
+
+
+def test_create_project_success(monkeypatch, qtbot, tmp_path):
+    main = DummyMainWindow()
+    dlg = WelcomeDialog(main)
+    qtbot.addWidget(dlg)
+
+    monkeypatch.setattr(QFileDialog, "getExistingDirectory", lambda *a, **k: str(tmp_path), raising=True)
+    monkeypatch.setattr(QInputDialog, "getText", lambda *a, **k: ("proj", True), raising=True)
+
+    captured = {}
+
+    class Result:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(cmd, capture_output=True, text=True, cwd=None):
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        return Result()
+
+    monkeypatch.setattr(subprocess, "run", fake_run, raising=True)
+
+    dlg.create_project()
+
+    expected = ["composer", "create-project", "laravel/laravel", str(tmp_path / "proj")]
+    assert captured["cmd"] == expected
+    assert captured["cwd"] is None
+    assert main.path == str(tmp_path / "proj")
+    assert main.saved
+
+
+def test_create_project_failure(monkeypatch, qtbot, tmp_path):
+    main = DummyMainWindow()
+    dlg = WelcomeDialog(main)
+    qtbot.addWidget(dlg)
+
+    monkeypatch.setattr(QFileDialog, "getExistingDirectory", lambda *a, **k: str(tmp_path), raising=True)
+    monkeypatch.setattr(QInputDialog, "getText", lambda *a, **k: ("proj", True), raising=True)
+
+    class Result:
+        returncode = 1
+        stdout = ""
+        stderr = "boom"
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: Result(), raising=True)
+
+    called = {}
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: called.setdefault("warn", True), raising=True)
+
+    dlg.create_project()
+
+    assert called.get("warn")
+    assert main.path is None
+    assert not main.saved


### PR DESCRIPTION
## Summary
- implement real project creation via composer
- prompt for location & project name
- run framework-specific create commands
- add unit tests for success & failure cases

## Testing
- `pytest -q`