### PR TITLE
Fix config copy with deepcopy

### DIFF
--- a/fusor/config.py
+++ b/fusor/config.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from copy import deepcopy
 
 # Path used to store user settings
 CONFIG_FILE = Path.home() / ".fusor_config.json"
@@ -46,7 +47,7 @@ def load_config():
         with config_path.open("r", encoding="utf-8") as f:
             data = json.load(f)
         if not isinstance(data, dict):
-            return DEFAULT_CONFIG.copy()
+            return deepcopy(DEFAULT_CONFIG)
         for key, value in DEFAULT_CONFIG.items():
             data.setdefault(key, value)
 
@@ -85,10 +86,10 @@ def load_config():
 
         return data
     except FileNotFoundError:
-        return DEFAULT_CONFIG.copy()
+        return deepcopy(DEFAULT_CONFIG)
     except json.JSONDecodeError:
         print("Failed to load config: invalid JSON")
-        return DEFAULT_CONFIG.copy()
+        return deepcopy(DEFAULT_CONFIG)
 
 
 def save_config(data):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,3 +42,14 @@ def test_load_invalid_json(tmp_path, monkeypatch):
     cfg_file.write_text("{ invalid json")
     monkeypatch.setattr(config, "CONFIG_FILE", str(cfg_file))
     assert config.load_config() == DEFAULT_CONFIG
+
+
+def test_load_returns_copy(tmp_path, monkeypatch):
+    """Modifying the loaded config should not affect DEFAULT_CONFIG."""
+    cfg_file = tmp_path / "missing.json"
+    monkeypatch.setattr(config, "CONFIG_FILE", str(cfg_file))
+    loaded = config.load_config()
+    loaded["projects"].append({"path": "/foo", "name": "foo"})
+    loaded["window_size"][0] = 500
+    assert DEFAULT_CONFIG["projects"] == []
+    assert DEFAULT_CONFIG["window_size"] == [1024, 768]


### PR DESCRIPTION
## Summary
- use `deepcopy` for default config
- ensure `load_config()` returns a separate instance of the default config

## Testing
- `ruff check .`
- `mypy fusor`
- `pytest -q`