### PR TITLE
Add optional Terminal tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,22 +25,20 @@ Fusor aims to **simplify routine PHP project operations** via a user-friendly vi
 -   Git, database, and migration helpers
 -   Configurable log viewer with auto-refresh
 -   Isolated settings stored in `~/.fusor_config.json`
--   Optional built-in terminal for shell commands
 
 ---
 
 ## Tab Overview
 
-| Tab          | Description |
-| ------------ | ------------------------------------------------------------------------------- |
+| Tab          | Description                                                                       |
+| ------------ | --------------------------------------------------------------------------------- |
 | **Project**  | Start/stop server, Composer install/update, PHP tools (PHPUnit, Rector, CS-Fixer) |
-| **Git**      | Switch branches, view status or diff, pull, hard reset, stash changes |
-| **Database** | Dump or restore SQL, run migrations, seed data |
+| **Git**      | Switch branches, view status or diff, pull, hard reset, stash changes             |
+| **Database** | Dump or restore SQL, run migrations, seed data                                    |
 | **Docker**   | Build, pull, restart services, inspect containers _(visible only in Docker mode)_ |
-| **Yii**      | Common Yii console commands _(visible when framework is Yii)_ |
-| **Logs**     | View logs with optional auto-refresh |
-| **Terminal** | Embedded shell for running commands *(optional)* |
-| **Settings** | Choose framework, set PHP binary, Docker config, and manage project list |
+| **Yii**      | Common Yii console commands _(visible when framework is Yii)_                     |
+| **Logs**     | View logs with optional auto-refresh                                              |
+| **Settings** | Choose framework, set PHP binary, Docker config, and manage project list          |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,20 +25,22 @@ Fusor aims to **simplify routine PHP project operations** via a user-friendly vi
 -   Git, database, and migration helpers
 -   Configurable log viewer with auto-refresh
 -   Isolated settings stored in `~/.fusor_config.json`
+-   Optional built-in terminal for shell commands
 
 ---
 
 ## Tab Overview
 
-| Tab          | Description                                                                       |
-| ------------ | --------------------------------------------------------------------------------- |
+| Tab          | Description |
+| ------------ | ------------------------------------------------------------------------------- |
 | **Project**  | Start/stop server, Composer install/update, PHP tools (PHPUnit, Rector, CS-Fixer) |
-| **Git**      | Switch branches, view status or diff, pull, hard reset, stash changes             |
-| **Database** | Dump or restore SQL, run migrations, seed data                                    |
+| **Git**      | Switch branches, view status or diff, pull, hard reset, stash changes |
+| **Database** | Dump or restore SQL, run migrations, seed data |
 | **Docker**   | Build, pull, restart services, inspect containers _(visible only in Docker mode)_ |
-| **Yii**      | Common Yii console commands _(visible when framework is Yii)_                     |
-| **Logs**     | View logs with optional auto-refresh                                              |
-| **Settings** | Choose framework, set PHP binary, Docker config, and manage project list          |
+| **Yii**      | Common Yii console commands _(visible when framework is Yii)_ |
+| **Logs**     | View logs with optional auto-refresh |
+| **Terminal** | Embedded shell for running commands *(optional)* |
+| **Settings** | Choose framework, set PHP binary, Docker config, and manage project list |
 
 ---
 

--- a/fusor/config.py
+++ b/fusor/config.py
@@ -22,6 +22,7 @@ DEFAULT_PROJECT_SETTINGS = {
     "compose_profile": "",
     "auto_refresh_secs": 5,
     "max_log_lines": DEFAULT_MAX_LOG_LINES,
+    "enable_terminal": False,
 }
 
 # Default configuration values

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -49,6 +49,7 @@ from .tabs.symfony_tab import SymfonyTab
 from .tabs.yii_tab import YiiTab
 from .tabs.docker_tab import DockerTab
 from .tabs.logs_tab import LogsTab
+from .tabs.terminal_tab import TerminalTab
 from .tabs.settings_tab import SettingsTab
 
 # allow tests to monkeypatch file operations easily
@@ -281,6 +282,7 @@ class MainWindow(QMainWindow):
         self.compose_profile_edit: QLineEdit | None = None
         self.refresh_spin: QSpinBox | None = None
         self.theme_combo: QComboBox | None = None
+        self.terminal_checkbox: QCheckBox | None = None
         self.log_view: QTextEdit | None = None
 
         self.tabs = QTabWidget()
@@ -339,6 +341,7 @@ class MainWindow(QMainWindow):
         self.log_paths: list[str] = []
         self.git_remote = ""
         self.max_log_lines = DEFAULT_MAX_LOG_LINES
+        self.enable_terminal = False
         self.auto_refresh_secs = 5
         self.load_config()
         apply_theme(self, self.theme)
@@ -368,6 +371,9 @@ class MainWindow(QMainWindow):
         self.logs_tab = LogsTab(self)
         self.tabs.addTab(self.logs_tab, "Logs")
 
+        self.terminal_tab = TerminalTab(self)
+        self.terminal_index = self.tabs.addTab(self.terminal_tab, "Terminal")
+
         self.settings_tab = SettingsTab(self)
         self.settings_index = self.tabs.addTab(self.settings_tab, "Settings")
         self.update_settings_tab_title()
@@ -388,6 +394,10 @@ class MainWindow(QMainWindow):
         show_yii = self.framework_choice == "Yii"
         self.tabs.setTabVisible(self.yii_index, show_yii)
         self.tabs.setTabEnabled(self.yii_index, show_yii)
+
+        # terminal tab availability
+        self.tabs.setTabVisible(self.terminal_index, self.enable_terminal)
+        self.tabs.setTabEnabled(self.terminal_index, self.enable_terminal)
 
         # populate settings widgets with loaded values
         if self.project_combo is not None:
@@ -487,6 +497,10 @@ class MainWindow(QMainWindow):
             "auto_refresh_secs",
             data.get("auto_refresh_secs", self.auto_refresh_secs),
         )
+        self.enable_terminal = settings.get(
+            "enable_terminal",
+            data.get("enable_terminal", self.enable_terminal),
+        )
 
         self.theme = data.get("theme", self.theme)
 
@@ -559,6 +573,9 @@ class MainWindow(QMainWindow):
         self.max_log_lines = int(
             cast(Any, settings.get("max_log_lines", self.max_log_lines))
         )
+        self.enable_terminal = bool(
+            settings.get("enable_terminal", self.enable_terminal)
+        )
 
         if self.framework_combo is not None:
             self.framework_combo.setCurrentText(self.framework_choice)
@@ -592,8 +609,13 @@ class MainWindow(QMainWindow):
             self.compose_profile_edit.setText(self.compose_profile)
         if self.refresh_spin is not None:
             self.refresh_spin.setValue(self.auto_refresh_secs)
+        if self.terminal_checkbox is not None:
+            self.terminal_checkbox.setChecked(self.enable_terminal)
         if hasattr(self, "logs_tab"):
             self.logs_tab.update_timer_interval(self.auto_refresh_secs)
+        if hasattr(self, "terminal_index"):
+            self.tabs.setTabVisible(self.terminal_index, self.enable_terminal)
+            self.tabs.setTabEnabled(self.terminal_index, self.enable_terminal)
 
         self.mark_settings_saved()
 
@@ -668,6 +690,10 @@ class MainWindow(QMainWindow):
             self.project_name_edit.setText(proj.get("name", Path(path).name))
         if hasattr(self, "git_tab"):
             self.git_tab.load_branches()
+
+        if hasattr(self, "terminal_index"):
+            self.tabs.setTabVisible(self.terminal_index, self.enable_terminal)
+            self.tabs.setTabEnabled(self.terminal_index, self.enable_terminal)
 
         self.apply_project_settings()
 
@@ -885,6 +911,11 @@ class MainWindow(QMainWindow):
             if self.theme_combo is not None
             else self.theme
         )
+        enable_terminal = (
+            self.terminal_checkbox.isChecked()
+            if self.terminal_checkbox is not None
+            else self.enable_terminal
+        )
 
         if (
             not project_path
@@ -950,6 +981,7 @@ class MainWindow(QMainWindow):
         self.compose_profile = compose_profile.strip()
         self.auto_refresh_secs = int(auto_refresh_secs)
         self.theme = theme
+        self.enable_terminal = enable_terminal
         self.max_log_lines = int(getattr(self, "max_log_lines", DEFAULT_MAX_LOG_LINES))
 
         data = load_config()
@@ -967,6 +999,7 @@ class MainWindow(QMainWindow):
             "compose_profile": self.compose_profile,
             "auto_refresh_secs": self.auto_refresh_secs,
             "max_log_lines": self.max_log_lines,
+            "enable_terminal": self.enable_terminal,
         }
         data.update(
             {

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -437,8 +437,12 @@ class SettingsTab(QWidget):
 
     def on_terminal_toggled(self, checked: bool) -> None:
         if hasattr(self.main_window, "terminal_index"):
-            self.main_window.tabs.setTabVisible(self.main_window.terminal_index, checked)
-            self.main_window.tabs.setTabEnabled(self.main_window.terminal_index, checked)
+            self.main_window.tabs.setTabVisible(
+                self.main_window.terminal_index, checked
+            )
+            self.main_window.tabs.setTabEnabled(
+                self.main_window.terminal_index, checked
+            )
 
     def add_project(self) -> None:
         directory = QFileDialog.getExistingDirectory(

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -197,6 +197,11 @@ class SettingsTab(QWidget):
             self.theme_combo.setCurrentText("Light")
         misc_form.addRow("Theme:", self.theme_combo)
 
+        self.terminal_checkbox = QCheckBox("Enable Terminal Tab")
+        self.terminal_checkbox.setChecked(self.main_window.enable_terminal)
+        self.terminal_checkbox.setMinimumHeight(30)
+        misc_form.addRow("", self.terminal_checkbox)
+
         self.yii_template_combo = QComboBox()
         self.yii_template_combo.addItems(["basic", "advanced"])
         if hasattr(self.main_window, "yii_template"):
@@ -209,6 +214,7 @@ class SettingsTab(QWidget):
         self.docker_checkbox.setChecked(self.main_window.use_docker)
         self.docker_checkbox.setMinimumHeight(30)
         self.docker_checkbox.toggled.connect(self.on_docker_toggled)
+        self.terminal_checkbox.toggled.connect(self.on_terminal_toggled)
         docker_form.addRow("", self.docker_checkbox)
 
         project_group.setLayout(project_form)
@@ -246,8 +252,10 @@ class SettingsTab(QWidget):
         self.main_window.compose_profile_edit = self.compose_profile_edit
         self.main_window.refresh_spin = self.refresh_spin
         self.main_window.theme_combo = self.theme_combo
+        self.main_window.terminal_checkbox = self.terminal_checkbox
 
         self.on_docker_toggled(self.docker_checkbox.isChecked())
+        self.on_terminal_toggled(self.terminal_checkbox.isChecked())
         current_fw = self.framework_combo.currentText()
         self.on_framework_changed(current_fw)
         self.main_window.database_tab.on_framework_changed(current_fw)
@@ -275,6 +283,9 @@ class SettingsTab(QWidget):
         self.docker_checkbox.toggled.connect(self.main_window.mark_settings_dirty)
         self.refresh_spin.valueChanged.connect(self.main_window.mark_settings_dirty)
         self.theme_combo.currentTextChanged.connect(
+            self.main_window.mark_settings_dirty
+        )
+        self.terminal_checkbox.toggled.connect(
             self.main_window.mark_settings_dirty
         )
         self.project_name_edit.textChanged.connect(self.main_window.mark_settings_dirty)
@@ -423,6 +434,11 @@ class SettingsTab(QWidget):
         if hasattr(self.main_window, "docker_index"):
             self.main_window.tabs.setTabVisible(self.main_window.docker_index, checked)
             self.main_window.tabs.setTabEnabled(self.main_window.docker_index, checked)
+
+    def on_terminal_toggled(self, checked: bool) -> None:
+        if hasattr(self.main_window, "terminal_index"):
+            self.main_window.tabs.setTabVisible(self.main_window.terminal_index, checked)
+            self.main_window.tabs.setTabEnabled(self.main_window.terminal_index, checked)
 
     def add_project(self) -> None:
         directory = QFileDialog.getExistingDirectory(

--- a/fusor/tabs/terminal_tab.py
+++ b/fusor/tabs/terminal_tab.py
@@ -72,7 +72,10 @@ class TerminalTab(QWidget):
     # actions
     # ------------------------------------------------------------------
     def start_shell(self) -> None:
-        if self.process is not None and self.process.state() == QProcess.ProcessState.Running:
+        if (
+            self.process is not None
+            and self.process.state() == QProcess.ProcessState.Running
+        ):
             return
         self.process = QProcess(self)
         self.process.readyReadStandardOutput.connect(self._handle_output)

--- a/fusor/tabs/terminal_tab.py
+++ b/fusor/tabs/terminal_tab.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import os
+from PyQt6.QtCore import QProcess
+from PyQt6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QPlainTextEdit,
+    QLineEdit,
+    QPushButton,
+)
+
+
+class TerminalTab(QWidget):
+    """Simple embedded terminal using QProcess."""
+
+    def __init__(self, main_window):
+        super().__init__()
+        self.main_window = main_window
+        self.process: QProcess | None = None
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(20, 20, 20, 20)
+        layout.setSpacing(12)
+
+        self.output = QPlainTextEdit()
+        self.output.setReadOnly(True)
+        layout.addWidget(self.output)
+
+        input_layout = QHBoxLayout()
+        self.input_edit = QLineEdit()
+        self.input_edit.returnPressed.connect(self.send_input)
+        input_layout.addWidget(self.input_edit)
+        send_btn = QPushButton("Send")
+        send_btn.clicked.connect(self.send_input)
+        input_layout.addWidget(send_btn)
+        layout.addLayout(input_layout)
+
+        btn_layout = QHBoxLayout()
+        self.start_btn = QPushButton("Start Shell")
+        self.start_btn.clicked.connect(self.start_shell)
+        btn_layout.addWidget(self.start_btn)
+        self.stop_btn = QPushButton("Stop")
+        self.stop_btn.setEnabled(False)
+        self.stop_btn.clicked.connect(self.stop_shell)
+        btn_layout.addWidget(self.stop_btn)
+        layout.addLayout(btn_layout)
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _shell_program(self) -> str:
+        if os.name == "nt":
+            return "cmd.exe"
+        return os.environ.get("SHELL", "/bin/sh")
+
+    def _handle_output(self) -> None:
+        if not self.process:
+            return
+        out = bytes(self.process.readAllStandardOutput().data()).decode(
+            errors="ignore"
+        )
+        err = bytes(self.process.readAllStandardError().data()).decode(
+            errors="ignore"
+        )
+        text = out + err
+        if text:
+            self.output.appendPlainText(text.rstrip())
+
+    # ------------------------------------------------------------------
+    # actions
+    # ------------------------------------------------------------------
+    def start_shell(self) -> None:
+        if self.process is not None and self.process.state() == QProcess.ProcessState.Running:
+            return
+        self.process = QProcess(self)
+        self.process.readyReadStandardOutput.connect(self._handle_output)
+        self.process.readyReadStandardError.connect(self._handle_output)
+        self.process.finished.connect(self._on_finished)
+        program = self._shell_program()
+        if self.main_window.project_path:
+            self.process.setWorkingDirectory(self.main_window.project_path)
+        self.process.start(program)
+        self.start_btn.setEnabled(False)
+        self.stop_btn.setEnabled(True)
+
+    def _on_finished(self):
+        self.start_btn.setEnabled(True)
+        self.stop_btn.setEnabled(False)
+        self.process = None
+
+    def stop_shell(self) -> None:
+        if self.process and self.process.state() == QProcess.ProcessState.Running:
+            self.process.kill()
+            self.process = None
+            self.start_btn.setEnabled(True)
+            self.stop_btn.setEnabled(False)
+
+    def send_input(self) -> None:
+        if not self.process or self.process.state() != QProcess.ProcessState.Running:
+            return
+        text = self.input_edit.text()
+        if not text:
+            return
+        self.process.write((text + "\n").encode())
+        self.output.appendPlainText(f"$ {text}")
+        self.input_edit.clear()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,6 +22,7 @@ def test_save_then_load(tmp_path, monkeypatch):
                 "git_remote": "origin",
                 "compose_files": ["dc.yml"],
                 "auto_refresh_secs": 7,
+                "enable_terminal": False,
             }
         },
         "theme": "light",

--- a/tests/test_settings_tab.py
+++ b/tests/test_settings_tab.py
@@ -18,6 +18,7 @@ class DummyMainWindow:
         self.auto_refresh_secs = 5
         self.theme = "dark"
         self.git_remote = ""
+        self.enable_terminal = False
         self.git_tab = type("G", (), {"get_remotes": lambda self: []})()
         self.database_tab = type("D", (), {"on_framework_changed": lambda self, t: None})()
         self.mark_settings_dirty = lambda *a, **k: None

--- a/tests/test_terminal_tab.py
+++ b/tests/test_terminal_tab.py
@@ -1,0 +1,46 @@
+from PyQt6.QtCore import QProcess
+from fusor.tabs.terminal_tab import TerminalTab
+
+class DummyMainWindow:
+    def __init__(self):
+        self.project_path = "/proj"
+
+def test_start_and_stop_shell(monkeypatch, qtbot):
+    main = DummyMainWindow()
+    tab = TerminalTab(main)
+    qtbot.addWidget(tab)
+
+    started = []
+    killed = []
+
+    class DummyProc:
+        ProcessState = QProcess.ProcessState
+
+        def __init__(self, *args, **kwargs):
+            self._state = QProcess.ProcessState.NotRunning
+            self.readyReadStandardOutput = type("Sig", (), {"connect": lambda *a, **k: None})()
+            self.readyReadStandardError = type("Sig", (), {"connect": lambda *a, **k: None})()
+            self.finished = type("Sig", (), {"connect": lambda *a, **k: None})()
+        def start(self, program):
+            started.append(program)
+            self._state = QProcess.ProcessState.Running
+        def state(self):
+            return self._state
+        def kill(self):
+            killed.append(True)
+            self._state = QProcess.ProcessState.NotRunning
+        def write(self, *_a):
+            pass
+        def setWorkingDirectory(self, *_a):
+            pass
+    monkeypatch.setattr("fusor.tabs.terminal_tab.QProcess", DummyProc)
+
+    tab.start_shell()
+    assert started
+    assert not tab.start_btn.isEnabled()
+    assert tab.stop_btn.isEnabled()
+
+    tab.stop_shell()
+    assert killed
+    assert tab.start_btn.isEnabled()
+    assert not tab.stop_btn.isEnabled()


### PR DESCRIPTION
## Summary
- implement `TerminalTab` using `QProcess` for an embedded shell
- expose terminal toggle in the settings tab
- persist `enable_terminal` per project in the config
- integrate terminal tab into `MainWindow`
- add tests for starting and stopping the shell
- update existing tests for new setting

## Testing
- `ruff check .`
- `mypy fusor`
- `pytest -q`