### PR TITLE
Add commit functionality to GitTab

### DIFF
--- a/fusor/tabs/git_tab.py
+++ b/fusor/tabs/git_tab.py
@@ -71,6 +71,20 @@ class GitTab(QWidget):
         create_group.setLayout(create_layout)
         outer_layout.addWidget(create_group)
 
+        # --- Commit Changes ---
+        commit_group = QGroupBox("Commit Changes")
+        commit_layout = QHBoxLayout()
+        self.commit_message_edit = QLineEdit()
+        commit_btn = self._btn(
+            "Commit",
+            self.commit_changes,
+            icon="document-save",
+        )
+        commit_layout.addWidget(self.commit_message_edit)
+        commit_layout.addWidget(commit_btn)
+        commit_group.setLayout(commit_layout)
+        outer_layout.addWidget(commit_group)
+
         # --- Git actions ---
         actions_group = QGroupBox("Git Commands")
         actions_layout = QVBoxLayout()
@@ -284,6 +298,12 @@ class GitTab(QWidget):
         self.current_branch = branch
         width = self.main_window.width() if hasattr(self.main_window, "width") else 800
         self.update_responsive_layout(width)
+
+    def commit_changes(self) -> None:
+        message = self.commit_message_edit.text().strip()
+        if not message:
+            return
+        self.run_git_command("commit", "-m", message)
 
     def get_remotes(self) -> list[str]:
         if not self.main_window.project_path:

--- a/tests/test_git_tab.py
+++ b/tests/test_git_tab.py
@@ -297,3 +297,28 @@ def test_branch_truncates_on_small_width(qtbot):
 
     tab.update_responsive_layout(800)
     assert tab.current_branch_label.text() == long_branch
+
+
+def test_commit_button_runs_commit(monkeypatch, qtbot):
+    main = DummyMainWindow()
+    tab = GitTab(main)
+    qtbot.addWidget(tab)
+
+    called = {}
+
+    def fake_run_git_command(*args):
+        called["args"] = args
+
+    monkeypatch.setattr(tab, "run_git_command", fake_run_git_command, raising=True)
+
+    commit_btn: QPushButton | None = None
+    for btn in tab.findChildren(QPushButton):
+        if btn.text() == "Commit":
+            commit_btn = btn
+            break
+    assert commit_btn is not None
+
+    tab.commit_message_edit.setText("initial commit")
+    qtbot.mouseClick(commit_btn, Qt.MouseButton.LeftButton)
+
+    assert called["args"] == ("commit", "-m", "initial commit")


### PR DESCRIPTION
## Summary
- allow committing from Git tab
- test commit button

## Testing
- `pytest -q`