### PR TITLE
Add log follow mode

### DIFF
--- a/fusor/tabs/logs_tab.py
+++ b/fusor/tabs/logs_tab.py
@@ -11,7 +11,8 @@ from PyQt6.QtWidgets import (
     QComboBox,
     QScrollArea,
 )
-from PyQt6.QtCore import QTimer, Qt
+import os
+from PyQt6.QtCore import QTimer, Qt, QProcess
 from PyQt6.QtGui import QTextCursor
 from ..icons import get_icon
 from ..utils import expand_log_paths
@@ -117,6 +118,15 @@ class LogsTab(QWidget):
             self.auto_checkbox, alignment=Qt.AlignmentFlag.AlignVCenter
         )
 
+        self.follow_checkbox = QCheckBox("Follow")
+        self.follow_checkbox.setMinimumHeight(36)
+        self.follow_checkbox.setChecked(False)
+        control_layout.addWidget(
+            self.follow_checkbox, alignment=Qt.AlignmentFlag.AlignVCenter
+        )
+
+        self.follow_process: QProcess | None = None
+
         control_box.setLayout(control_layout)
         outer_layout.addWidget(control_box)
 
@@ -130,6 +140,10 @@ class LogsTab(QWidget):
         self.update_timer_interval(self.main_window.auto_refresh_secs)
         self._timer.timeout.connect(self.main_window.refresh_logs)
         self.auto_checkbox.toggled.connect(self.on_auto_refresh_toggled)
+        self.follow_checkbox.toggled.connect(self.on_follow_toggled)
+        self.log_selector.currentIndexChanged.connect(
+            self.on_log_selection_changed
+        )
 
     def update_timer_interval(self, seconds: int) -> None:
         self._timer.setInterval(int(seconds) * 1000)
@@ -148,6 +162,64 @@ class LogsTab(QWidget):
             self.main_window.refresh_logs()
         else:
             self._timer.stop()
+
+    # ------------------------------------------------------------------
+    # Follow mode handling
+    # ------------------------------------------------------------------
+    def _append_follow_output(self) -> None:
+        if not self.follow_process:
+            return
+        out = bytes(self.follow_process.readAllStandardOutput().data()).decode(
+            errors="ignore"
+        )
+        err = bytes(self.follow_process.readAllStandardError().data()).decode(
+            errors="ignore"
+        )
+        text = out + err
+        if text:
+            cursor = self.log_view.textCursor()
+            cursor.movePosition(QTextCursor.MoveOperation.End)
+            self.log_view.setTextCursor(cursor)
+            self.log_view.insertPlainText(text)
+            self.log_view.moveCursor(QTextCursor.MoveOperation.End)
+
+    def _start_follow_process(self) -> None:
+        self._stop_follow_process()
+        path = self.log_selector.currentData()
+        if not path:
+            self.follow_checkbox.setChecked(False)
+            return
+        if not os.path.isabs(path):
+            path = os.path.join(self.main_window.project_path, path)
+        self.main_window.refresh_logs()
+        proc = QProcess(self)
+        if os.name == "nt":
+            program = "powershell"
+            args = [
+                "-Command",
+                f"Get-Content -Path '{path}' -Wait -Tail 0",
+            ]
+            proc.start(program, args)
+        else:
+            proc.start("tail", ["-F", path])
+        proc.readyReadStandardOutput.connect(self._append_follow_output)
+        proc.readyReadStandardError.connect(self._append_follow_output)
+        self.follow_process = proc
+
+    def _stop_follow_process(self) -> None:
+        if self.follow_process and self.follow_process.state() == QProcess.ProcessState.Running:
+            self.follow_process.kill()
+        self.follow_process = None
+
+    def on_follow_toggled(self, checked: bool) -> None:
+        if checked:
+            self._start_follow_process()
+        else:
+            self._stop_follow_process()
+
+    def on_log_selection_changed(self) -> None:
+        if self.follow_process:
+            self._start_follow_process()
 
     def search_logs(self) -> None:
         text = self.search_edit.text().strip()

--- a/tests/test_logs_tab.py
+++ b/tests/test_logs_tab.py
@@ -1,4 +1,4 @@
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import Qt, QProcess
 
 from fusor.tabs.logs_tab import LogsTab
 
@@ -161,3 +161,106 @@ def test_set_log_dirs_expands_directory(tmp_path, qtbot):
     items = [tab.log_selector.itemText(i) for i in range(tab.log_selector.count())]
     expected = ["All logs"] + [str(logs / f"log{i}.log") for i in range(2)]
     assert items == expected
+
+
+def test_follow_start_stop(monkeypatch, qtbot):
+    main = DummyMainWindow()
+    tab = LogsTab(main)
+    qtbot.addWidget(tab)
+
+    started: list[tuple[str, list[str]]] = []
+    killed = []
+
+    class DummyProc:
+        ProcessState = QProcess.ProcessState
+
+        def __init__(self, *_a, **_k):
+            self._state = QProcess.ProcessState.NotRunning
+            self.readyReadStandardOutput = type("Sig", (), {"connect": lambda *a, **k: None})()
+            self.readyReadStandardError = type("Sig", (), {"connect": lambda *a, **k: None})()
+
+        def start(self, program: str, args: list[str]):
+            started.append((program, args))
+            self._state = QProcess.ProcessState.Running
+
+        def kill(self):
+            killed.append(True)
+            self._state = QProcess.ProcessState.NotRunning
+
+        def state(self):
+            return self._state
+
+        def readAllStandardOutput(self):
+            return b""
+
+        def readAllStandardError(self):
+            return b""
+
+    monkeypatch.setattr("fusor.tabs.logs_tab.QProcess", DummyProc)
+
+    tab.log_selector.addItem("file.log", "file.log")
+    tab.log_selector.setCurrentIndex(1)
+
+    tab.follow_checkbox.setChecked(True)
+    qtbot.wait(10)
+
+    assert started
+    assert tab.follow_process is not None
+
+    tab.follow_checkbox.setChecked(False)
+    qtbot.wait(10)
+
+    assert killed
+    assert tab.follow_process is None
+
+
+def test_follow_restarts_on_log_change(monkeypatch, qtbot):
+    main = DummyMainWindow()
+    tab = LogsTab(main)
+    qtbot.addWidget(tab)
+
+    started = []
+    killed = []
+
+    class DummyProc:
+        ProcessState = QProcess.ProcessState
+
+        def __init__(self, *_a, **_k):
+            self._state = QProcess.ProcessState.NotRunning
+            self.readyReadStandardOutput = type("Sig", (), {"connect": lambda *a, **k: None})()
+            self.readyReadStandardError = type("Sig", (), {"connect": lambda *a, **k: None})()
+
+        def start(self, program: str, args: list[str]):
+            started.append((program, args))
+            self._state = QProcess.ProcessState.Running
+
+        def kill(self):
+            killed.append(True)
+            self._state = QProcess.ProcessState.NotRunning
+
+        def state(self):
+            return self._state
+
+        def readAllStandardOutput(self):
+            return b""
+
+        def readAllStandardError(self):
+            return b""
+
+    monkeypatch.setattr("fusor.tabs.logs_tab.QProcess", DummyProc)
+
+    tab.log_selector.addItem("a.log", "a.log")
+    tab.log_selector.addItem("b.log", "b.log")
+    tab.log_selector.setCurrentIndex(1)
+
+    tab.follow_checkbox.setChecked(True)
+    qtbot.wait(10)
+
+    assert len(started) == 1
+
+    tab.log_selector.setCurrentIndex(2)
+    qtbot.wait(10)
+
+    assert len(killed) == 1
+    assert len(started) == 2
+


### PR DESCRIPTION
## Summary
- add a Follow checkbox to the Logs tab
- implement log tailing via `QProcess`
- clean up tail process when disabled or log changes
- add tests for follow mode behaviour

## Testing
- `pytest tests/test_logs_tab.py::test_follow_start_stop tests/test_logs_tab.py::test_follow_restarts_on_log_change -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bfd97996c8322a79132fe9d73e0c4