### PR TITLE
Remove "All logs" option from log tab

### DIFF
--- a/fusor/tabs/logs_tab.py
+++ b/fusor/tabs/logs_tab.py
@@ -151,7 +151,6 @@ class LogsTab(QWidget):
 
     def set_log_dirs(self, paths: list[str]) -> None:
         self.log_selector.clear()
-        self.log_selector.addItem("All logs", None)
         expanded = expand_log_paths(self.main_window.project_path, paths)
         for p in expanded:
             self.log_selector.addItem(p, p)

--- a/tests/test_logs_tab.py
+++ b/tests/test_logs_tab.py
@@ -159,7 +159,7 @@ def test_set_log_dirs_expands_directory(tmp_path, qtbot):
     qtbot.addWidget(tab)
 
     items = [tab.log_selector.itemText(i) for i in range(tab.log_selector.count())]
-    expected = ["All logs"] + [str(logs / f"log{i}.log") for i in range(2)]
+    expected = [str(logs / f"log{i}.log") for i in range(2)]
     assert items == expected
 
 

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -495,9 +495,8 @@ class TestMainWindow:
 
         main_window.refresh_logs()
 
-        assert opened == [str(p) for p in paths]
-        for i in range(3):
-            assert f"msg{i}" in main_window.log_view.text
+        assert opened == [str(paths[0])]
+        assert "msg0" in main_window.log_view.text
 
     def test_refresh_logs_reads_directory(self, tmp_path: Path, main_window, monkeypatch):
         logs_dir = tmp_path / "logs"
@@ -524,9 +523,8 @@ class TestMainWindow:
 
         main_window.refresh_logs()
 
-        assert opened == [str(p) for p in files]
-        for i in range(2):
-            assert f"msg{i}" in main_window.log_view.text
+        assert opened == [str(files[0])]
+        assert "msg0" in main_window.log_view.text
 
     def test_yii_template_row_visibility(self, main_window, qtbot):
         main_window.framework_combo.setCurrentText("None")


### PR DESCRIPTION
## Summary
- remove the "All logs" choice from the log selector
- adjust tests for new default behaviour showing only the first log file

## Testing
- `pytest -q`