### PR TITLE
Embed project settings in projects list

### DIFF
--- a/fusor/config.py
+++ b/fusor/config.py
@@ -30,13 +30,12 @@ DEFAULT_PROJECT_SETTINGS = {
 }
 
 # Default configuration values
-# ``projects`` previously stored a list of paths.  To allow storing extra
-# information per project (like a display name) it now stores a list of
-# dictionaries with at least ``path`` and ``name`` keys.
+# ``projects`` stores a list of dictionaries.  Each dictionary includes at
+# minimum ``path`` and ``name`` along with per-project settings like
+# ``framework`` or ``php_path``.
 DEFAULT_CONFIG = {
     "projects": [],  # list[dict]
     "current_project": "",
-    "project_settings": {},
     "theme": "dark",
     # Window geometry (width, height) and position (x, y)
     "window_size": [1024, 768],
@@ -55,39 +54,55 @@ def load_config():
         for key, value in DEFAULT_CONFIG.items():
             data.setdefault(key, value)
 
-        # migrate list of project paths into list of dicts
-        projects = []
+        # normalize project entries to dicts
+        projects: list[dict] = []
         for entry in data.get("projects", []):
             if isinstance(entry, str):
                 projects.append({"path": entry, "name": Path(entry).name})
             elif isinstance(entry, dict) and "path" in entry:
-                proj = {
-                    "path": entry["path"],
-                    "name": entry.get("name", Path(entry["path"]).name),
-                }
+                proj = {"path": entry["path"], "name": entry.get("name", Path(entry["path"]).name)}
                 for k, v in entry.items():
                     if k not in proj:
                         proj[k] = v
                 projects.append(proj)
         data["projects"] = projects
 
-        # migrate old flat settings into per-project block
+        # migrate old project_settings block into projects
+        proj_settings = data.pop("project_settings", {})
+        if isinstance(proj_settings, dict):
+            for path, settings in proj_settings.items():
+                proj = next((p for p in data["projects"] if p.get("path") == path), None)
+                if proj is None:
+                    proj = {"path": path, "name": Path(path).name}
+                    data["projects"].append(proj)
+                if isinstance(settings, dict):
+                    if "log_path" in settings and "log_dirs" not in settings:
+                        settings["log_dirs"] = [settings["log_path"]]
+                    if "log_paths" in settings and "log_dirs" not in settings:
+                        settings["log_dirs"] = settings.pop("log_paths")
+                    for k, v in settings.items():
+                        proj.setdefault(k, v)
+
+        # migrate old flat settings into current project entry
         current = data.get("current_project") or data.get("project_path")
         if current:
-            settings = data.setdefault("project_settings", {}).setdefault(current, {})
+            proj = next((p for p in data["projects"] if p.get("path") == current), None)
+            if proj is None:
+                proj = {"path": current, "name": Path(current).name}
+                data["projects"].append(proj)
             for k in DEFAULT_PROJECT_SETTINGS:
-                if k in data and k not in settings:
-                    settings[k] = data[k]
-            if "log_path" in data and "log_dirs" not in settings:
-                settings["log_dirs"] = [data["log_path"]]
-            if "log_paths" in settings and "log_dirs" not in settings:
-                settings["log_dirs"] = settings.pop("log_paths")
+                if k in data and k not in proj:
+                    proj[k] = data[k]
+            if "log_path" in data and "log_dirs" not in proj:
+                proj["log_dirs"] = [data["log_path"]]
+            if "log_paths" in proj:
+                proj["log_dirs"] = proj.pop("log_paths")
 
         if "project_path" in data and data["project_path"]:
             path = data["project_path"]
             if not any(p.get("path") == path for p in data["projects"]):
                 data["projects"].append({"path": path, "name": Path(path).name})
-            if not data["current_project"]:
+            if not data.get("current_project"):
                 data["current_project"] = path
 
         return data

--- a/fusor/config.py
+++ b/fusor/config.py
@@ -67,22 +67,6 @@ def load_config():
                 projects.append(proj)
         data["projects"] = projects
 
-        # migrate old project_settings block into projects
-        proj_settings = data.pop("project_settings", {})
-        if isinstance(proj_settings, dict):
-            for path, settings in proj_settings.items():
-                proj = next((p for p in data["projects"] if p.get("path") == path), None)
-                if proj is None:
-                    proj = {"path": path, "name": Path(path).name}
-                    data["projects"].append(proj)
-                if isinstance(settings, dict):
-                    if "log_path" in settings and "log_dirs" not in settings:
-                        settings["log_dirs"] = [settings["log_path"]]
-                    if "log_paths" in settings and "log_dirs" not in settings:
-                        settings["log_dirs"] = settings.pop("log_paths")
-                    for k, v in settings.items():
-                        proj.setdefault(k, v)
-
         # migrate old flat settings into current project entry
         current = data.get("current_project") or data.get("project_path")
         if current:

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -525,13 +525,10 @@ class SettingsTab(QWidget):
             else:
                 self.main_window.project_path = ""
 
-        settings = data.get("project_settings", {})
-        settings.pop(path, None)
         data.update(
             {
                 "projects": self.main_window.projects,
                 "current_project": self.main_window.project_path,
-                "project_settings": settings,
             }
         )
         save_config(data)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,11 +9,9 @@ def test_save_then_load(tmp_path, monkeypatch):
         "bar": [1, 2, 3],
         "projects": [
             {"path": "/one", "name": "one"},
-            {"path": "/two", "name": "two"},
-        ],
-        "current_project": "/two",
-        "project_settings": {
-            "/two": {
+            {
+                "path": "/two",
+                "name": "two",
                 "use_docker": True,
                 "php_service": "php",
                 "server_port": 9000,
@@ -23,8 +21,9 @@ def test_save_then_load(tmp_path, monkeypatch):
                 "compose_files": ["dc.yml"],
                 "auto_refresh_secs": 7,
                 "enable_terminal": False,
-            }
-        },
+            },
+        ],
+        "current_project": "/two",
         "theme": "light",
         "window_size": [800, 600],
         "window_position": [10, 20],

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -646,9 +646,8 @@ class TestMainWindow:
         monkeypatch.setattr(
             "fusor.tabs.settings_tab.load_config",
             lambda: {
-                "projects": [{"path": "/one", "name": "one"}],
+                "projects": [{"path": "/one", "name": "one", "server_port": 8000}],
                 "current_project": "/one",
-                "project_settings": {"/one": {"server_port": 8000}},
             },
             raising=True,
         )
@@ -670,7 +669,6 @@ class TestMainWindow:
         assert win.project_path == ""
         assert saved["projects"] == []
         assert saved["current_project"] == ""
-        assert "/one" not in saved.get("project_settings", {})
         assert shown
         win.close()
 
@@ -722,7 +720,7 @@ class TestMainWindow:
         main_window.save_settings()
 
         assert not warnings
-        assert saved["project_settings"]["/tmp"]["php_path"] == "php"
+        assert saved["projects"][0]["php_path"] == "php"
 
     def test_project_change_updates_settings(self, qtbot, monkeypatch):
         monkeypatch.setattr(QTimer, "singleShot", lambda *a, **k: None, raising=True)
@@ -731,14 +729,10 @@ class TestMainWindow:
             "load_config",
             lambda: {
                 "projects": [
-                    {"path": "/one", "name": "one"},
-                    {"path": "/two", "name": "two"},
+                    {"path": "/one", "name": "one", "server_port": 8000},
+                    {"path": "/two", "name": "two", "server_port": 8001},
                 ],
                 "current_project": "/one",
-                "project_settings": {
-                    "/one": {"server_port": 8000},
-                    "/two": {"server_port": 8001},
-                },
             },
             raising=True,
         )
@@ -993,7 +987,7 @@ class TestMainWindow:
         main_window.save_settings()
 
         assert main_window.compose_files == ["a.yml", "b.yml"]
-        assert saved["project_settings"]["/tmp"]["compose_files"] == ["a.yml", "b.yml"]
+        assert saved["projects"][0]["compose_files"] == ["a.yml", "b.yml"]
 
     def test_save_settings_updates_project_name(self, main_window, monkeypatch):
         main_window.project_combo.addItem("/tmp", "/tmp")
@@ -1012,8 +1006,8 @@ class TestMainWindow:
 
         main_window.save_settings()
 
-        assert main_window.projects == [{"path": "/tmp", "name": "MyProj"}]
-        assert saved["projects"] == [{"path": "/tmp", "name": "MyProj"}]
+        assert main_window.projects[0]["name"] == "MyProj"
+        assert saved["projects"][0]["name"] == "MyProj"
         assert main_window.project_combo.itemText(0) == "MyProj"
 
     def test_start_project_includes_compose_profile(self, tmp_path: Path, main_window, monkeypatch):


### PR DESCRIPTION
## Summary
- move per-project settings into each `projects` entry
- adapt config loading to migrate old structure
- update `MainWindow` and Settings tab to work with new format
- adjust tests for new config structure

## Testing
- `pytest -q`