### PR TITLE
Refresh logs on file selector change

### DIFF
--- a/fusor/tabs/logs_tab.py
+++ b/fusor/tabs/logs_tab.py
@@ -43,6 +43,9 @@ class LogsTab(QWidget):
         # --- Log Selector ---
         self.log_selector = QComboBox()
         self.set_log_dirs(self.main_window.log_dirs)
+        self.log_selector.currentIndexChanged.connect(
+            self.main_window.refresh_logs
+        )
         outer_layout.addWidget(self.log_selector)
 
         # --- Search ---

--- a/tests/test_logs_tab.py
+++ b/tests/test_logs_tab.py
@@ -145,7 +145,7 @@ def test_responsive_layout_hides_log_view(qtbot):
     assert tab.log_view.isVisible()
     assert tab.prev_btn.isVisible()
     assert tab.next_btn.isVisible()
-    
+
 def test_set_log_dirs_expands_directory(tmp_path, qtbot):
     logs = tmp_path / "logs"
     logs.mkdir()
@@ -162,22 +162,3 @@ def test_set_log_dirs_expands_directory(tmp_path, qtbot):
     expected = [str(logs / f"log{i}.log") for i in range(2)]
     assert items == expected
 
-
-def test_log_selector_change_triggers_refresh(qtbot):
-    called = []
-
-    main = DummyMainWindow()
-
-    def refresh():
-        called.append(True)
-
-    main.refresh_logs = refresh
-    main.log_dirs = ["one.log", "two.log"]
-
-    tab = LogsTab(main)
-    qtbot.addWidget(tab)
-
-    tab.log_selector.setCurrentIndex(1)
-    qtbot.wait(10)
-
-    assert called

--- a/tests/test_logs_tab.py
+++ b/tests/test_logs_tab.py
@@ -145,7 +145,7 @@ def test_responsive_layout_hides_log_view(qtbot):
     assert tab.log_view.isVisible()
     assert tab.prev_btn.isVisible()
     assert tab.next_btn.isVisible()
-
+    
 def test_set_log_dirs_expands_directory(tmp_path, qtbot):
     logs = tmp_path / "logs"
     logs.mkdir()
@@ -162,3 +162,22 @@ def test_set_log_dirs_expands_directory(tmp_path, qtbot):
     expected = [str(logs / f"log{i}.log") for i in range(2)]
     assert items == expected
 
+
+def test_log_selector_change_triggers_refresh(qtbot):
+    called = []
+
+    main = DummyMainWindow()
+
+    def refresh():
+        called.append(True)
+
+    main.refresh_logs = refresh
+    main.log_dirs = ["one.log", "two.log"]
+
+    tab = LogsTab(main)
+    qtbot.addWidget(tab)
+
+    tab.log_selector.setCurrentIndex(1)
+    qtbot.wait(10)
+
+    assert called

--- a/tests/test_logs_tab.py
+++ b/tests/test_logs_tab.py
@@ -161,3 +161,23 @@ def test_set_log_dirs_expands_directory(tmp_path, qtbot):
     items = [tab.log_selector.itemText(i) for i in range(tab.log_selector.count())]
     expected = [str(logs / f"log{i}.log") for i in range(2)]
     assert items == expected
+
+
+def test_log_selector_change_triggers_refresh(qtbot):
+    called = []
+
+    main = DummyMainWindow()
+
+    def refresh():
+        called.append(True)
+
+    main.refresh_logs = refresh
+    main.log_dirs = ["one.log", "two.log"]
+
+    tab = LogsTab(main)
+    qtbot.addWidget(tab)
+
+    tab.log_selector.setCurrentIndex(1)
+    qtbot.wait(10)
+
+    assert called


### PR DESCRIPTION
## Summary
- refresh logs when log file selection changes
- test that selecting a different log file triggers refresh

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`