### PR TITLE
Hide log tab when framework none

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -376,7 +376,7 @@ class MainWindow(QMainWindow):
         self.docker_index = self.tabs.addTab(self.docker_tab, "Docker")
 
         self.logs_tab = LogsTab(self)
-        self.tabs.addTab(self.logs_tab, "Logs")
+        self.logs_index = self.tabs.addTab(self.logs_tab, "Logs")
 
         self.terminal_tab = TerminalTab(self)
         self.terminal_index = self.tabs.addTab(self.terminal_tab, "Terminal")
@@ -401,6 +401,10 @@ class MainWindow(QMainWindow):
         show_yii = self.framework_choice == "Yii"
         self.tabs.setTabVisible(self.yii_index, show_yii)
         self.tabs.setTabEnabled(self.yii_index, show_yii)
+
+        log_visible = self.framework_choice in ["Laravel", "Symfony", "Yii"]
+        self.tabs.setTabVisible(self.logs_index, log_visible)
+        self.tabs.setTabEnabled(self.logs_index, log_visible)
 
         # terminal tab availability
         self.tabs.setTabVisible(self.terminal_index, self.enable_terminal)

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -175,6 +175,7 @@ class SettingsTab(QWidget):
         self.log_dirs_container = self._wrap(self.log_dirs_layout)
         self.log_dir_label = QLabel("Log Directories:")
         logs_group = QGroupBox("Logs")
+        self.logs_group = logs_group
         logs_form = QFormLayout()
         logs_form.setLabelAlignment(Qt.AlignmentFlag.AlignRight)
         logs_form.addRow(self.log_dir_label, self.log_dirs_container)
@@ -575,6 +576,8 @@ class SettingsTab(QWidget):
         self.log_dirs_container.setVisible(log_visible)
         self.log_dir_label.setVisible(log_visible)
         self.add_log_btn.setVisible(log_visible)
+        if hasattr(self, "logs_group"):
+            self.logs_group.setVisible(log_visible)
         if log_visible:
             template = self.yii_template_combo.currentText()
             paths = self.main_window.default_log_dirs(text, template)
@@ -599,6 +602,10 @@ class SettingsTab(QWidget):
                 show = text == fw
                 self.main_window.tabs.setTabVisible(idx, show)
                 self.main_window.tabs.setTabEnabled(idx, show)
+
+        if hasattr(self.main_window, "logs_index"):
+            self.main_window.tabs.setTabVisible(self.main_window.logs_index, log_visible)
+            self.main_window.tabs.setTabEnabled(self.main_window.logs_index, log_visible)
 
     def on_yii_template_changed(self, text: str) -> None:
         if self.framework_combo.currentText() != "Yii":

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -558,6 +558,29 @@ class TestMainWindow:
         assert not main_window.settings_tab.log_dirs_container.isHidden()
         assert not main_window.settings_tab.log_dir_label.isHidden()
 
+    def test_logs_tab_visibility(self, main_window, qtbot):
+        assert main_window.tabs.isTabVisible(main_window.logs_index)
+        assert main_window.tabs.isTabEnabled(main_window.logs_index)
+
+        main_window.framework_combo.setCurrentText("None")
+        qtbot.wait(10)
+        assert not main_window.tabs.isTabVisible(main_window.logs_index)
+        assert not main_window.tabs.isTabEnabled(main_window.logs_index)
+
+        main_window.framework_combo.setCurrentText("Laravel")
+        qtbot.wait(10)
+        assert main_window.tabs.isTabVisible(main_window.logs_index)
+        assert main_window.tabs.isTabEnabled(main_window.logs_index)
+
+    def test_logs_group_visibility(self, main_window, qtbot):
+        main_window.framework_combo.setCurrentText("None")
+        qtbot.wait(10)
+        assert main_window.settings_tab.logs_group.isHidden()
+
+        main_window.framework_combo.setCurrentText("Symfony")
+        qtbot.wait(10)
+        assert not main_window.settings_tab.logs_group.isHidden()
+
     def test_default_log_dirs_per_framework(self, main_window, qtbot):
         main_window.framework_combo.setCurrentText("Laravel")
         qtbot.wait(10)


### PR DESCRIPTION
## Summary
- add logs_index to manage visibility of log tab
- store logs_group widget and control its visibility
- toggle logs tab and group when framework changes
- test logs tab and group visibility

## Testing
- `pytest -q`