### PR TITLE
Add Node tab with npm helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Fusor aims to **simplify routine PHP project operations** via a user-friendly vi
 -   Project switching and per-project settings
 -   Optional **Docker mode** for containerized workflows
 -   Git, database, and migration helpers
+-   Basic Node/NPM commands
 -   Configurable log viewer with auto-refresh
 -   Isolated settings stored in `~/.fusor_config.json`
 
@@ -38,6 +39,7 @@ Fusor aims to **simplify routine PHP project operations** via a user-friendly vi
 | **Git**      | Switch branches, view status or diff, pull, hard reset, stash changes             |
 | **Database** | Dump or restore SQL, run migrations, seed data                                    |
 | **Docker**   | Build, pull, restart services, inspect containers _(visible only in Docker mode)_ |
+| **Node**     | Run npm install, dev, and build commands |
 | **Yii**      | Common Yii console commands _(visible when framework is Yii)_                     |
 | **Logs**     | View logs with optional auto-refresh                                              |
 | **Settings** | Choose framework, set PHP binary, Docker config, and manage project list          |

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -49,6 +49,7 @@ from .tabs.database_tab import DatabaseTab
 from .tabs.laravel_tab import LaravelTab
 from .tabs.symfony_tab import SymfonyTab
 from .tabs.yii_tab import YiiTab
+from .tabs.node_tab import NodeTab
 from .tabs.docker_tab import DockerTab
 from .tabs.logs_tab import LogsTab
 from .tabs.terminal_tab import TerminalTab
@@ -374,6 +375,9 @@ class MainWindow(QMainWindow):
 
         self.docker_tab = DockerTab(self)
         self.docker_index = self.tabs.addTab(self.docker_tab, "Docker")
+
+        self.node_tab = NodeTab(self)
+        self.node_index = self.tabs.addTab(self.node_tab, "Node")
 
         self.logs_tab = LogsTab(self)
         self.logs_index = self.tabs.addTab(self.logs_tab, "Logs")

--- a/fusor/tabs/__init__.py
+++ b/fusor/tabs/__init__.py
@@ -1,4 +1,5 @@
 from .symfony_tab import SymfonyTab
 from .yii_tab import YiiTab
+from .node_tab import NodeTab
 
-__all__ = ["SymfonyTab", "YiiTab"]
+__all__ = ["SymfonyTab", "YiiTab", "NodeTab"]

--- a/fusor/tabs/node_tab.py
+++ b/fusor/tabs/node_tab.py
@@ -1,0 +1,54 @@
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QPushButton, QSizePolicy, QScrollArea
+from typing import Callable
+
+from ..icons import get_icon
+
+
+class NodeTab(QWidget):
+    """Simple helpers for npm-based workflows."""
+
+    def __init__(self, main_window):
+        super().__init__()
+        self.main_window = main_window
+
+        main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        main_layout.addWidget(scroll)
+
+        container = QWidget()
+        scroll.setWidget(container)
+
+        layout = QVBoxLayout(container)
+        layout.setContentsMargins(20, 20, 20, 20)
+        layout.setSpacing(12)
+
+        self.npm_install_btn = self._btn("npm install", self.npm_install, icon="system-run")
+        self.npm_dev_btn = self._btn("npm run dev", self.npm_run_dev, icon="system-run")
+        self.npm_build_btn = self._btn("npm run build", self.npm_run_build, icon="system-run")
+
+        layout.addWidget(self.npm_install_btn)
+        layout.addWidget(self.npm_dev_btn)
+        layout.addWidget(self.npm_build_btn)
+
+        layout.addStretch(1)
+
+    def _btn(self, text: str, slot: Callable[[], None], icon: str | None = None) -> QPushButton:
+        btn = QPushButton(text)
+        if icon:
+            btn.setIcon(get_icon(icon))
+        btn.setMinimumHeight(36)
+        btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        btn.clicked.connect(slot)
+        return btn
+
+    def npm_install(self) -> None:
+        self.main_window.run_command(["npm", "install"])
+
+    def npm_run_dev(self) -> None:
+        self.main_window.run_command(["npm", "run", "dev"])
+
+    def npm_run_build(self) -> None:
+        self.main_window.run_command(["npm", "run", "build"])

--- a/tests/test_node_tab.py
+++ b/tests/test_node_tab.py
@@ -1,0 +1,27 @@
+from PyQt6.QtCore import Qt
+
+from fusor.tabs.node_tab import NodeTab
+
+
+class DummyMainWindow:
+    def __init__(self):
+        self.commands = []
+
+    def run_command(self, cmd):
+        self.commands.append(cmd)
+
+
+def test_buttons_run_commands(qtbot):
+    main = DummyMainWindow()
+    tab = NodeTab(main)
+    qtbot.addWidget(tab)
+
+    qtbot.mouseClick(tab.npm_install_btn, Qt.MouseButton.LeftButton)
+    qtbot.mouseClick(tab.npm_dev_btn, Qt.MouseButton.LeftButton)
+    qtbot.mouseClick(tab.npm_build_btn, Qt.MouseButton.LeftButton)
+
+    assert main.commands == [
+        ["npm", "install"],
+        ["npm", "run", "dev"],
+        ["npm", "run", "build"],
+    ]


### PR DESCRIPTION
## Summary
- add Node tab for running npm commands
- export NodeTab
- wire Node tab into the main window
- test Node tab button actions
- document Node tab in README

## Testing
- `pytest -q`
- `pytest tests/test_node_tab.py -q`