### PR TITLE
Add configurable DB service

### DIFF
--- a/fusor/config.py
+++ b/fusor/config.py
@@ -13,6 +13,7 @@ DEFAULT_PROJECT_SETTINGS = {
     "framework": "Laravel",
     "php_path": "php",
     "php_service": "php",
+    "db_service": "db",
     # path of the project inside docker containers
     "docker_project_path": "/app",
     "server_port": 8000,

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -276,6 +276,7 @@ class MainWindow(QMainWindow):
         self.framework_combo: QComboBox | None = None
         self.php_path_edit: QLineEdit | None = None
         self.php_service_edit: QLineEdit | None = None
+        self.db_service_edit: QLineEdit | None = None
         self.server_port_edit: QSpinBox | None = None
         self.docker_project_path_edit: QLineEdit | None = None
         self.docker_checkbox: QCheckBox | None = None
@@ -338,6 +339,7 @@ class MainWindow(QMainWindow):
         self.framework_choice = "Laravel"
         self.php_path = "php"
         self.php_service = "php"
+        self.db_service = "db"
         self.docker_project_path = "/app"
         self.server_port = 8000
         self.use_docker = False
@@ -491,6 +493,9 @@ class MainWindow(QMainWindow):
         self.php_service = settings.get(
             "php_service", data.get("php_service", self.php_service)
         )
+        self.db_service = settings.get(
+            "db_service", data.get("db_service", self.db_service)
+        )
         self.docker_project_path = settings.get(
             "docker_project_path",
             data.get("docker_project_path", self.docker_project_path),
@@ -608,6 +613,7 @@ class MainWindow(QMainWindow):
         self.framework_choice = cast(str, settings["framework"])
         self.php_path = cast(str, settings["php_path"])
         self.php_service = cast(str, settings["php_service"])
+        self.db_service = cast(str, settings.get("db_service", "db"))
         self.docker_project_path = cast(str, settings.get("docker_project_path", "/app"))
         self.server_port = int(cast(Any, settings["server_port"]))
         self.use_docker = bool(settings["use_docker"])
@@ -641,6 +647,8 @@ class MainWindow(QMainWindow):
             self.php_path_edit.setText(self.php_path)
         if self.php_service_edit is not None:
             self.php_service_edit.setText(self.php_service)
+        if self.db_service_edit is not None:
+            self.db_service_edit.setText(self.db_service)
         if self.server_port_edit is not None:
             self.server_port_edit.setValue(self.server_port)
         if self.docker_checkbox is not None:
@@ -691,7 +699,7 @@ class MainWindow(QMainWindow):
         ):
             self.project_tab.update_php_tools()
 
-    def run_command(self, command: list[str]) -> None:
+    def run_command(self, command: list[str], service: str | None = None) -> None:
         if self.use_docker:
             if len(command) >= 2 and command[0] == "docker" and command[1] == "compose":
                 command = self._compose_prefix() + command[2:]
@@ -699,7 +707,7 @@ class MainWindow(QMainWindow):
                 command = self._compose_prefix() + [
                     "exec",
                     "-T",
-                    self.php_service,
+                    service or self.php_service,
                     *command,
                 ]
             cwd = self.project_path
@@ -926,6 +934,11 @@ class MainWindow(QMainWindow):
             if self.php_service_edit is not None
             else self.php_service
         )
+        db_service = (
+            self.db_service_edit.text()
+            if self.db_service_edit is not None
+            else self.db_service
+        )
         server_port = (
             self.server_port_edit.value()
             if self.server_port_edit is not None
@@ -1051,6 +1064,7 @@ class MainWindow(QMainWindow):
         self.framework_choice = framework
         self.php_path = php_path
         self.php_service = php_service or self.php_service
+        self.db_service = db_service or self.db_service
         self.server_port = server_port
         self.use_docker = use_docker
         self.yii_template = yii_template
@@ -1076,6 +1090,7 @@ class MainWindow(QMainWindow):
                     "framework": framework,
                     "php_path": php_path,
                     "php_service": php_service,
+                    "db_service": db_service,
                     "server_port": server_port,
                     "use_docker": use_docker,
                     "yii_template": yii_template,
@@ -1101,6 +1116,7 @@ class MainWindow(QMainWindow):
                     "framework": framework,
                     "php_path": php_path,
                     "php_service": php_service,
+                    "db_service": db_service,
                     "server_port": server_port,
                     "use_docker": use_docker,
                     "yii_template": yii_template,

--- a/fusor/tabs/database_tab.py
+++ b/fusor/tabs/database_tab.py
@@ -76,18 +76,22 @@ class DatabaseTab(QWidget):
         return btn
 
     def open_dbeaver(self) -> None:
-        self.main_window.run_command(["dbeaver"])
+        self.main_window.run_command(["dbeaver"], service=self.main_window.db_service)
 
     def dump_sql(self) -> None:
         path, _ = QFileDialog.getSaveFileName(
             self, "Save SQL Dump", filter="SQL Files (*.sql)"
         )
         if path:
-            self.main_window.run_command(["mysqldump", "--result-file", path])
+            self.main_window.run_command([
+                "mysqldump",
+                "--result-file",
+                path,
+            ], service=self.main_window.db_service)
 
     def restore_dump(self) -> None:
         path, _ = QFileDialog.getOpenFileName(
             self, "Select SQL Dump", filter="SQL Files (*.sql)"
         )
         if path:
-            self.main_window.run_command(["mysql", path])
+            self.main_window.run_command(["mysql", path], service=self.main_window.db_service)

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -94,10 +94,12 @@ class SettingsTab(QWidget):
         php_form.addRow("PHP Executable:", self._wrap(php_path_row))
 
         self.php_service_edit = QLineEdit(self.main_window.php_service)
+        self.db_service_edit = QLineEdit(self.main_window.db_service)
         docker_group = QGroupBox("Docker")
         docker_form = QFormLayout()
         docker_form.setLabelAlignment(Qt.AlignmentFlag.AlignRight)
         docker_form.addRow("PHP Service:", self.php_service_edit)
+        docker_form.addRow("DB Service:", self.db_service_edit)
 
         self.server_port_edit = QSpinBox()
         self.server_port_edit.setRange(1, 65535)
@@ -252,6 +254,7 @@ class SettingsTab(QWidget):
         self.main_window.framework_combo = self.framework_combo
         self.main_window.php_path_edit = self.php_path_edit
         self.main_window.php_service_edit = self.php_service_edit
+        self.main_window.db_service_edit = self.db_service_edit
         self.main_window.server_port_edit = self.server_port_edit
         self.main_window.docker_checkbox = self.docker_checkbox
         self.main_window.yii_template_combo = self.yii_template_combo
@@ -281,6 +284,7 @@ class SettingsTab(QWidget):
         )
         self.php_path_edit.textChanged.connect(self.main_window.mark_settings_dirty)
         self.php_service_edit.textChanged.connect(self.main_window.mark_settings_dirty)
+        self.db_service_edit.textChanged.connect(self.main_window.mark_settings_dirty)
         self.server_port_edit.valueChanged.connect(self.main_window.mark_settings_dirty)
         self.framework_combo.currentTextChanged.connect(
             self.main_window.mark_settings_dirty
@@ -443,6 +447,7 @@ class SettingsTab(QWidget):
         self.php_path_edit.setEnabled(not checked)
         self.php_browse_btn.setEnabled(not checked)
         self.php_service_edit.setEnabled(checked)
+        self.db_service_edit.setEnabled(checked)
         self.server_port_edit.setEnabled(not checked)
         self.compose_files_container.setEnabled(checked)
         self.compose_label.setEnabled(checked)

--- a/tests/test_database_tab.py
+++ b/tests/test_database_tab.py
@@ -7,12 +7,13 @@ class DummyMainWindow:
     def __init__(self):
         self.commands = []
         self.framework_choice = "Laravel"
+        self.db_service = "db"
 
     # stubs used by buttons but not tested here
     migrate = rollback = fresh = seed = lambda self: None
 
-    def run_command(self, cmd):
-        self.commands.append(cmd)
+    def run_command(self, cmd, service=None):
+        self.commands.append((cmd, service))
 
 
 def test_dbeaver_button_runs_command(monkeypatch, qtbot):
@@ -22,7 +23,7 @@ def test_dbeaver_button_runs_command(monkeypatch, qtbot):
 
     qtbot.mouseClick(tab.dbeaver_btn, Qt.MouseButton.LeftButton)
 
-    assert main.commands == [["dbeaver"]]
+    assert main.commands == [(["dbeaver"], "db")]
 
 
 def test_dump_button_runs_command(monkeypatch, qtbot):
@@ -38,7 +39,7 @@ def test_dump_button_runs_command(monkeypatch, qtbot):
 
     qtbot.mouseClick(tab.dump_btn, Qt.MouseButton.LeftButton)
 
-    assert main.commands == [["mysqldump", "--result-file", "/tmp/d.sql"]]
+    assert main.commands == [(["mysqldump", "--result-file", "/tmp/d.sql"], "db")]
 
 
 def test_restore_button_runs_command(monkeypatch, qtbot):
@@ -54,6 +55,23 @@ def test_restore_button_runs_command(monkeypatch, qtbot):
 
     qtbot.mouseClick(tab.restore_btn, Qt.MouseButton.LeftButton)
 
-    assert main.commands == [["mysql", "/tmp/d.sql"]]
+    assert main.commands == [(["mysql", "/tmp/d.sql"], "db")]
+
+
+def test_service_name_passed(monkeypatch, qtbot):
+    main = DummyMainWindow()
+    main.db_service = "maria"
+    tab = DatabaseTab(main)
+    qtbot.addWidget(tab)
+
+    monkeypatch.setattr(
+        "PyQt6.QtWidgets.QFileDialog.getSaveFileName",
+        lambda *a, **k: ("/tmp/d.sql", ""),
+        raising=True,
+    )
+
+    qtbot.mouseClick(tab.dump_btn, Qt.MouseButton.LeftButton)
+
+    assert main.commands == [(["mysqldump", "--result-file", "/tmp/d.sql"], "maria")]
 
 

--- a/tests/test_settings_tab.py
+++ b/tests/test_settings_tab.py
@@ -9,6 +9,7 @@ class DummyMainWindow:
         self.framework_choice = "None"
         self.php_path = "php"
         self.php_service = "php"
+        self.db_service = "db"
         self.server_port = 8000
         self.compose_files = []
         self.compose_profile = ""


### PR DESCRIPTION
## Summary
- allow configuring Docker DB service in project settings
- update settings UI with DB Service field
- support passing service name to `run_command`
- respect DB service for database commands
- test database tab service handling

## Testing
- `pytest -q`