### PR TITLE
Add optional console output setting

### DIFF
--- a/fusor/config.py
+++ b/fusor/config.py
@@ -29,6 +29,7 @@ DEFAULT_PROJECT_SETTINGS = {
     "open_browser": False,
     "max_log_lines": DEFAULT_MAX_LOG_LINES,
     "enable_terminal": False,
+    "show_console_output": False,
 }
 
 # Default configuration values

--- a/fusor/config.py
+++ b/fusor/config.py
@@ -29,7 +29,6 @@ DEFAULT_PROJECT_SETTINGS = {
     "open_browser": False,
     "max_log_lines": DEFAULT_MAX_LOG_LINES,
     "enable_terminal": False,
-    "show_console_output": False,
 }
 
 # Default configuration values
@@ -40,6 +39,7 @@ DEFAULT_CONFIG = {
     "projects": [],  # list[dict]
     "current_project": "",
     "theme": "dark",
+    "show_console_output": False,
     # Window geometry (width, height) and position (x, y)
     "window_size": [1024, 768],
     "window_position": [100, 100],
@@ -69,6 +69,15 @@ def load_config():
                         proj_dict[k] = v
                 projects.append(proj_dict)
         data["projects"] = projects
+
+        # migrate old console output setting from projects
+        if "show_console_output" not in data:
+            for proj in data["projects"]:
+                if "show_console_output" in proj:
+                    data["show_console_output"] = bool(proj["show_console_output"])
+                    break
+        for proj in data["projects"]:
+            proj.pop("show_console_output", None)
 
         # migrate old flat settings into current project entry
         current = data.get("current_project") or data.get("project_path")

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -574,9 +574,7 @@ class MainWindow(QMainWindow):
             settings.get("open_browser", data.get("open_browser", self.open_browser))
         )
         self.show_console_output = bool(
-            settings.get(
-                "show_console_output", data.get("show_console_output", self.show_console_output)
-            )
+            data.get("show_console_output", self.show_console_output)
         )
 
         self.theme = data.get("theme", self.theme)
@@ -689,12 +687,8 @@ class MainWindow(QMainWindow):
         self.max_log_lines = int(
             cast(Any, settings.get("max_log_lines", self.max_log_lines))
         )
-        self.enable_terminal = bool(
-            settings.get("enable_terminal", self.enable_terminal)
-        )
-        self.show_console_output = bool(
-            settings.get("show_console_output", self.show_console_output)
-        )
+        self.enable_terminal = bool(settings.get("enable_terminal", self.enable_terminal))
+        self.show_console_output = bool(data.get("show_console_output", self.show_console_output))
 
         if self.framework_combo is not None:
             self.framework_combo.setCurrentText(self.framework_choice)
@@ -1179,12 +1173,13 @@ class MainWindow(QMainWindow):
                     "open_browser": self.open_browser,
                     "max_log_lines": self.max_log_lines,
                     "enable_terminal": self.enable_terminal,
-                    "show_console_output": self.show_console_output,
                 }
                 updated_projects.append(proj)
                 found = True
             else:
-                updated_projects.append(p.copy())
+                temp = p.copy()
+                temp.pop("show_console_output", None)
+                updated_projects.append(temp)
         if not found:
             updated_projects.append(
                 {
@@ -1206,7 +1201,6 @@ class MainWindow(QMainWindow):
                     "open_browser": self.open_browser,
                     "max_log_lines": self.max_log_lines,
                     "enable_terminal": self.enable_terminal,
-                    "show_console_output": self.show_console_output,
                 }
             )
         self.projects = updated_projects
@@ -1215,6 +1209,7 @@ class MainWindow(QMainWindow):
                 "projects": self.projects,
                 "current_project": project_path,
                 "theme": self.theme,
+                "show_console_output": self.show_console_output,
             }
         )
         try:

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -292,6 +292,7 @@ class MainWindow(QMainWindow):
         self.theme_combo: QComboBox | None = None
         self.terminal_checkbox: QCheckBox | None = None
         self.open_browser_checkbox: QCheckBox | None = None
+        self.console_output_checkbox: QCheckBox | None = None
         self.log_view: QTextEdit | None = None
 
         self.tabs = QTabWidget()
@@ -356,6 +357,7 @@ class MainWindow(QMainWindow):
         self.enable_terminal = False
         self.auto_refresh_secs = 5
         self.open_browser = False
+        self.show_console_output = False
         self.load_config()
         apply_theme(self, self.theme)
 
@@ -571,6 +573,11 @@ class MainWindow(QMainWindow):
         self.open_browser = bool(
             settings.get("open_browser", data.get("open_browser", self.open_browser))
         )
+        self.show_console_output = bool(
+            settings.get(
+                "show_console_output", data.get("show_console_output", self.show_console_output)
+            )
+        )
 
         self.theme = data.get("theme", self.theme)
 
@@ -627,7 +634,7 @@ class MainWindow(QMainWindow):
         """Adjust UI elements based on the current window size."""
         width = self.width()
 
-        show_output = width >= 700
+        show_output = width >= 700 and self.show_console_output
         self.output_view.setVisible(show_output)
         self.clear_output_button.setVisible(show_output)
 
@@ -685,6 +692,9 @@ class MainWindow(QMainWindow):
         self.enable_terminal = bool(
             settings.get("enable_terminal", self.enable_terminal)
         )
+        self.show_console_output = bool(
+            settings.get("show_console_output", self.show_console_output)
+        )
 
         if self.framework_combo is not None:
             self.framework_combo.setCurrentText(self.framework_choice)
@@ -730,6 +740,8 @@ class MainWindow(QMainWindow):
             self.terminal_checkbox.setChecked(self.enable_terminal)
         if self.open_browser_checkbox is not None:
             self.open_browser_checkbox.setChecked(self.open_browser)
+        if self.console_output_checkbox is not None:
+            self.console_output_checkbox.setChecked(self.show_console_output)
         if hasattr(self, "logs_tab"):
             self.logs_tab.update_timer_interval(self.auto_refresh_secs)
         if hasattr(self, "terminal_index"):
@@ -1061,6 +1073,11 @@ class MainWindow(QMainWindow):
             if self.terminal_checkbox is not None
             else self.enable_terminal
         )
+        show_console_output = (
+            self.console_output_checkbox.isChecked()
+            if self.console_output_checkbox is not None
+            else self.show_console_output
+        )
         open_browser = (
             self.open_browser_checkbox.isChecked()
             if self.open_browser_checkbox is not None
@@ -1135,6 +1152,7 @@ class MainWindow(QMainWindow):
         self.theme = theme
         self.enable_terminal = enable_terminal
         self.open_browser = bool(open_browser)
+        self.show_console_output = bool(show_console_output)
         self.max_log_lines = int(getattr(self, "max_log_lines", DEFAULT_MAX_LOG_LINES))
 
         data = load_config()
@@ -1161,6 +1179,7 @@ class MainWindow(QMainWindow):
                     "open_browser": self.open_browser,
                     "max_log_lines": self.max_log_lines,
                     "enable_terminal": self.enable_terminal,
+                    "show_console_output": self.show_console_output,
                 }
                 updated_projects.append(proj)
                 found = True
@@ -1187,6 +1206,7 @@ class MainWindow(QMainWindow):
                     "open_browser": self.open_browser,
                     "max_log_lines": self.max_log_lines,
                     "enable_terminal": self.enable_terminal,
+                    "show_console_output": self.show_console_output,
                 }
             )
         self.projects = updated_projects

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -213,6 +213,13 @@ class SettingsTab(QWidget):
             self.open_browser_checkbox.setChecked(self.main_window.open_browser)
         misc_form.addRow("", self.open_browser_checkbox)
 
+        self.console_output_checkbox = QCheckBox("Show Console Output")
+        if hasattr(self.main_window, "show_console_output"):
+            self.console_output_checkbox.setChecked(
+                self.main_window.show_console_output
+            )
+        misc_form.addRow("", self.console_output_checkbox)
+
         self.yii_template_combo = QComboBox()
         self.yii_template_combo.addItems(["basic", "advanced"])
         if hasattr(self.main_window, "yii_template"):
@@ -226,6 +233,7 @@ class SettingsTab(QWidget):
         self.docker_checkbox.setMinimumHeight(30)
         self.docker_checkbox.toggled.connect(self.on_docker_toggled)
         self.terminal_checkbox.toggled.connect(self.on_terminal_toggled)
+        self.console_output_checkbox.toggled.connect(self.on_console_output_toggled)
         docker_form.addRow("", self.docker_checkbox)
 
         project_group.setLayout(project_form)
@@ -267,9 +275,11 @@ class SettingsTab(QWidget):
         self.main_window.theme_combo = self.theme_combo
         self.main_window.terminal_checkbox = self.terminal_checkbox
         self.main_window.open_browser_checkbox = self.open_browser_checkbox
+        self.main_window.console_output_checkbox = self.console_output_checkbox
 
         self.on_docker_toggled(self.docker_checkbox.isChecked())
         self.on_terminal_toggled(self.terminal_checkbox.isChecked())
+        self.on_console_output_toggled(self.console_output_checkbox.isChecked())
         current_fw = self.framework_combo.currentText()
         self.on_framework_changed(current_fw)
         self.main_window.database_tab.on_framework_changed(current_fw)
@@ -304,6 +314,9 @@ class SettingsTab(QWidget):
             self.main_window.mark_settings_dirty
         )
         self.open_browser_checkbox.toggled.connect(
+            self.main_window.mark_settings_dirty
+        )
+        self.console_output_checkbox.toggled.connect(
             self.main_window.mark_settings_dirty
         )
         self.project_name_edit.textChanged.connect(self.main_window.mark_settings_dirty)
@@ -466,6 +479,11 @@ class SettingsTab(QWidget):
             self.main_window.tabs.setTabEnabled(
                 self.main_window.terminal_index, checked
             )
+
+    def on_console_output_toggled(self, checked: bool) -> None:
+        if hasattr(self.main_window, "output_view"):
+            self.main_window.show_console_output = checked
+            self.main_window._update_responsive_layout()
 
     def add_project(self) -> None:
         directory = QFileDialog.getExistingDirectory(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,6 +30,7 @@ def test_save_then_load(tmp_path, monkeypatch):
     }
     config.save_config(data)
     loaded = config.load_config()
+    data.setdefault("show_console_output", False)
     assert loaded == data
 
 def test_load_missing_file(tmp_path, monkeypatch):

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -1129,6 +1129,12 @@ class TestMainWindow:
         win.resize(900, 700)
         qtbot.wait(10)
 
+        assert not win.output_view.isVisible()
+        assert not win.clear_output_button.isVisible()
+
+        win.show_console_output = True
+        win._update_responsive_layout()
+
         assert win.output_view.isVisible()
         assert win.clear_output_button.isVisible()
 


### PR DESCRIPTION
## Summary
- add `show_console_output` to project config defaults
- hide output view unless `show_console_output` is enabled
- expose checkbox in Settings tab to toggle console output
- adjust tests for new default behaviour

## Testing
- `pytest -q`