### PR TITLE
Add docker exec support to TerminalTab

### DIFF
--- a/fusor/tabs/terminal_tab.py
+++ b/fusor/tabs/terminal_tab.py
@@ -89,7 +89,18 @@ class TerminalTab(QWidget):
         program = self._shell_program()
         if self.main_window.project_path:
             self.process.setWorkingDirectory(self.main_window.project_path)
-        self.process.start(program)
+        if getattr(self.main_window, "use_docker", False):
+            command = self.main_window._compose_prefix() + [
+                "exec",
+                "-T",
+                getattr(self.main_window, "php_service", "php"),
+            ]
+            if self.main_window.project_path:
+                command += ["-w", self.main_window.project_path]
+            command.append(program)
+            self.process.start(command[0], command[1:])
+        else:
+            self.process.start(program)
         self.start_btn.setEnabled(False)
         self.stop_btn.setEnabled(True)
         self.input_edit.setEnabled(True)

--- a/tests/test_terminal_tab.py
+++ b/tests/test_terminal_tab.py
@@ -1,9 +1,11 @@
 from PyQt6.QtCore import QProcess
 from fusor.tabs.terminal_tab import TerminalTab
 
+
 class DummyMainWindow:
     def __init__(self):
         self.project_path = "/proj"
+
 
 def test_start_and_stop_shell(monkeypatch, qtbot):
     main = DummyMainWindow()
@@ -24,18 +26,24 @@ def test_start_and_stop_shell(monkeypatch, qtbot):
             self.readyReadStandardOutput = type("Sig", (), {"connect": lambda *a, **k: None})()
             self.readyReadStandardError = type("Sig", (), {"connect": lambda *a, **k: None})()
             self.finished = type("Sig", (), {"connect": lambda *a, **k: None})()
-        def start(self, program):
-            started.append(program)
+
+        def start(self, program, args=None):
+            started.append([program] + (args or []))
             self._state = QProcess.ProcessState.Running
+
         def state(self):
             return self._state
+
         def kill(self):
             killed.append(True)
             self._state = QProcess.ProcessState.NotRunning
+
         def write(self, *_a):
             pass
+
         def setWorkingDirectory(self, *_a):
             pass
+
     monkeypatch.setattr("fusor.tabs.terminal_tab.QProcess", DummyProc)
 
     tab.start_shell()
@@ -51,3 +59,64 @@ def test_start_and_stop_shell(monkeypatch, qtbot):
     assert not tab.stop_btn.isEnabled()
     assert not tab.input_edit.isEnabled()
     assert not tab.send_btn.isEnabled()
+
+
+def test_start_shell_docker_exec(monkeypatch, qtbot):
+    class DockerMain(DummyMainWindow):
+        def __init__(self):
+            super().__init__()
+            self.use_docker = True
+            self.php_service = "php"
+
+        def _compose_prefix(self):
+            return ["docker", "compose"]
+
+    main = DockerMain()
+    tab = TerminalTab(main)
+    qtbot.addWidget(tab)
+
+    monkeypatch.setattr(TerminalTab, "_shell_program", lambda self: "/bin/sh")
+
+    started = []
+    cwd_set = []
+
+    class DummyProc:
+        ProcessState = QProcess.ProcessState
+
+        def __init__(self, *args, **kwargs):
+            self._state = QProcess.ProcessState.NotRunning
+            self.readyReadStandardOutput = type("Sig", (), {"connect": lambda *a, **k: None})()
+            self.readyReadStandardError = type("Sig", (), {"connect": lambda *a, **k: None})()
+            self.finished = type("Sig", (), {"connect": lambda *a, **k: None})()
+
+        def start(self, program, args=None):
+            started.append([program] + (args or []))
+            self._state = QProcess.ProcessState.Running
+
+        def state(self):
+            return self._state
+
+        def kill(self):
+            self._state = QProcess.ProcessState.NotRunning
+
+        def write(self, *_a):
+            pass
+
+        def setWorkingDirectory(self, path):
+            cwd_set.append(path)
+
+    monkeypatch.setattr("fusor.tabs.terminal_tab.QProcess", DummyProc)
+
+    tab.start_shell()
+
+    assert cwd_set == ["/proj"]
+    assert started[0] == [
+        "docker",
+        "compose",
+        "exec",
+        "-T",
+        "php",
+        "-w",
+        "/proj",
+        "/bin/sh",
+    ]


### PR DESCRIPTION
## Summary
- run shell inside docker when enabled
- include working directory inside container and host
- test docker exec shell

## Testing
- `flake8`
- `pytest -q`