### PR TITLE
Add dynamic npm scripts to Node tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Fusor aims to **simplify routine PHP project operations** via a user-friendly vi
 -   Project switching and per-project settings
 -   Optional **Docker mode** for containerized workflows
 -   Git, database, and migration helpers
--   Basic Node/NPM commands
+-   Basic Node/NPM commands with automatic buttons for package scripts
 -   Configurable log viewer with auto-refresh
 -   Isolated settings stored in `~/.fusor_config.json`
 
@@ -42,7 +42,7 @@ Fusor aims to **simplify routine PHP project operations** via a user-friendly vi
 | **Symfony**  | Clear cache and manage Doctrine migrations _(visible when framework is Symfony)_               |
 | **Yii**      | Common Yii console commands _(visible when framework is Yii)_                                  |
 | **Docker**   | Build, pull, restart services, inspect containers _(visible only in Docker mode)_              |
-| **Node**     | Run npm install, dev, and build commands                                                       |
+| **Node**     | Run npm install/dev/build and any package scripts |
 | **Logs**     | View logs with optional auto-refresh and open log files in your default application            |
 | **.env**     | Edit the project's environment file                                                            |
 | **Terminal** | Embedded terminal for custom commands                                                          |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Fusor aims to **simplify routine PHP project operations** via a user-friendly vi
 | **Symfony**  | Clear cache and manage Doctrine migrations _(visible when framework is Symfony)_               |
 | **Yii**      | Common Yii console commands _(visible when framework is Yii)_                                  |
 | **Docker**   | Build, pull, restart services, inspect containers _(visible only in Docker mode)_              |
-| **Node**     | Run npm install/dev/build and any package scripts |
+| **Node**     | Run npm install and package scripts (e.g., dev, build) |
 | **Logs**     | View logs with optional auto-refresh and open log files in your default application            |
 | **.env**     | Edit the project's environment file                                                            |
 | **Terminal** | Embedded terminal for custom commands                                                          |

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -759,6 +759,9 @@ class MainWindow(QMainWindow):
         ):
             self.project_tab.update_php_tools()
 
+        if hasattr(self, "node_tab") and hasattr(self.node_tab, "update_npm_scripts"):
+            self.node_tab.update_npm_scripts()
+
     def run_command(self, command: list[str], service: str | None = None) -> None:
         if self.use_docker:
             if len(command) >= 2 and command[0] == "docker" and command[1] == "compose":

--- a/fusor/tabs/node_tab.py
+++ b/fusor/tabs/node_tab.py
@@ -34,13 +34,11 @@ class NodeTab(QWidget):
         layout.setContentsMargins(20, 20, 20, 20)
         layout.setSpacing(12)
 
-        self.npm_install_btn = self._btn("npm install", self.npm_install, icon="system-run")
-        self.npm_dev_btn = self._btn("npm run dev", self.npm_run_dev, icon="system-run")
-        self.npm_build_btn = self._btn("npm run build", self.npm_run_build, icon="system-run")
+        self.npm_install_btn = self._btn(
+            "npm install", self.npm_install, icon="system-run"
+        )
 
         layout.addWidget(self.npm_install_btn)
-        layout.addWidget(self.npm_dev_btn)
-        layout.addWidget(self.npm_build_btn)
 
         self.npm_scripts_group = QGroupBox("NPM Scripts")
         self.npm_scripts_layout = QVBoxLayout()
@@ -63,11 +61,6 @@ class NodeTab(QWidget):
     def npm_install(self) -> None:
         self.main_window.run_command(["npm", "install"])
 
-    def npm_run_dev(self) -> None:
-        self.main_window.run_command(["npm", "run", "dev"])
-
-    def npm_run_build(self) -> None:
-        self.main_window.run_command(["npm", "run", "build"])
 
     def update_npm_scripts(self) -> None:
         """Load npm scripts from package.json and create buttons."""

--- a/tests/test_node_tab.py
+++ b/tests/test_node_tab.py
@@ -1,3 +1,4 @@
+import json
 from PyQt6.QtCore import Qt
 
 from fusor.tabs.node_tab import NodeTab
@@ -5,6 +6,7 @@ from fusor.tabs.node_tab import NodeTab
 
 class DummyMainWindow:
     def __init__(self):
+        self.project_path = ""
         self.commands = []
 
     def run_command(self, cmd):
@@ -25,3 +27,37 @@ def test_buttons_run_commands(qtbot):
         ["npm", "run", "dev"],
         ["npm", "run", "build"],
     ]
+
+
+def test_update_npm_scripts_adds_buttons(tmp_path, qtbot):
+    pkg = {"scripts": {"start": "node index.js"}}
+    (tmp_path / "package.json").write_text(json.dumps(pkg))
+
+    main = DummyMainWindow()
+    main.project_path = str(tmp_path)
+    tab = NodeTab(main)
+    qtbot.addWidget(tab)
+    tab.update_npm_scripts()
+    tab.show()
+    qtbot.wait(10)
+
+    texts = [btn.text() for btn in tab._script_buttons]
+    assert "npm run start" in texts
+    assert tab.npm_scripts_group.isVisible()
+
+
+def test_script_button_runs_command(tmp_path, qtbot, monkeypatch):
+    pkg = {"scripts": {"start": "node index.js"}}
+    (tmp_path / "package.json").write_text(json.dumps(pkg))
+
+    main = DummyMainWindow()
+    main.project_path = str(tmp_path)
+    captured = []
+    monkeypatch.setattr(main, "run_command", lambda cmd: captured.append(cmd), raising=True)
+    tab = NodeTab(main)
+    qtbot.addWidget(tab)
+    tab.update_npm_scripts()
+    btn = tab._script_buttons[0]
+    qtbot.mouseClick(btn, Qt.MouseButton.LeftButton)
+
+    assert captured == [["npm", "run", "start"]]

--- a/tests/test_node_tab.py
+++ b/tests/test_node_tab.py
@@ -19,14 +19,8 @@ def test_buttons_run_commands(qtbot):
     qtbot.addWidget(tab)
 
     qtbot.mouseClick(tab.npm_install_btn, Qt.MouseButton.LeftButton)
-    qtbot.mouseClick(tab.npm_dev_btn, Qt.MouseButton.LeftButton)
-    qtbot.mouseClick(tab.npm_build_btn, Qt.MouseButton.LeftButton)
 
-    assert main.commands == [
-        ["npm", "install"],
-        ["npm", "run", "dev"],
-        ["npm", "run", "build"],
-    ]
+    assert main.commands == [["npm", "install"]]
 
 
 def test_update_npm_scripts_adds_buttons(tmp_path, qtbot):
@@ -61,3 +55,36 @@ def test_script_button_runs_command(tmp_path, qtbot, monkeypatch):
     qtbot.mouseClick(btn, Qt.MouseButton.LeftButton)
 
     assert captured == [["npm", "run", "start"]]
+
+
+def test_dev_and_build_scripts_added(tmp_path, qtbot):
+    pkg = {"scripts": {"dev": "vite", "build": "vite build"}}
+    (tmp_path / "package.json").write_text(json.dumps(pkg))
+
+    main = DummyMainWindow()
+    main.project_path = str(tmp_path)
+    tab = NodeTab(main)
+    qtbot.addWidget(tab)
+    tab.update_npm_scripts()
+
+    texts = [btn.text() for btn in tab._script_buttons]
+    assert texts.count("npm run dev") == 1
+    assert texts.count("npm run build") == 1
+
+
+def test_dev_and_build_buttons_run_commands(tmp_path, qtbot):
+    pkg = {"scripts": {"dev": "vite", "build": "vite build"}}
+    (tmp_path / "package.json").write_text(json.dumps(pkg))
+
+    main = DummyMainWindow()
+    main.project_path = str(tmp_path)
+    tab = NodeTab(main)
+    qtbot.addWidget(tab)
+    tab.update_npm_scripts()
+
+    dev_btn = next(btn for btn in tab._script_buttons if btn.text() == "npm run dev")
+    build_btn = next(btn for btn in tab._script_buttons if btn.text() == "npm run build")
+    qtbot.mouseClick(dev_btn, Qt.MouseButton.LeftButton)
+    qtbot.mouseClick(build_btn, Qt.MouseButton.LeftButton)
+
+    assert main.commands == [["npm", "run", "dev"], ["npm", "run", "build"]]


### PR DESCRIPTION
## Summary
- load package.json scripts in NodeTab
- display buttons for each script and reload on project change
- test npm script buttons
- mention new npm script buttons in README

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`