### PR TITLE
Fix docker exec workdir flag order

### DIFF
--- a/fusor/tabs/terminal_tab.py
+++ b/fusor/tabs/terminal_tab.py
@@ -93,11 +93,13 @@ class TerminalTab(QWidget):
             command = self.main_window._compose_prefix() + [
                 "exec",
                 "-T",
-                getattr(self.main_window, "php_service", "php"),
             ]
             if self.main_window.project_path:
                 command += ["-w", self.main_window.project_path]
-            command.append(program)
+            command += [
+                getattr(self.main_window, "php_service", "php"),
+                program,
+            ]
             self.process.start(command[0], command[1:])
         else:
             self.process.start(program)

--- a/tests/test_terminal_tab.py
+++ b/tests/test_terminal_tab.py
@@ -115,8 +115,8 @@ def test_start_shell_docker_exec(monkeypatch, qtbot):
         "compose",
         "exec",
         "-T",
-        "php",
         "-w",
         "/proj",
+        "php",
         "/bin/sh",
     ]


### PR DESCRIPTION
## Summary
- place `-w` before service name when starting shell inside Docker
- update tests

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`