### PR TITLE
Fix tray icon for notifications

### DIFF
--- a/fusor/icons.py
+++ b/fusor/icons.py
@@ -1,7 +1,19 @@
-from PyQt6.QtGui import QIcon
+from PyQt6.QtGui import QIcon, QPixmap
+from PyQt6.QtCore import Qt
 
 
 def get_icon(name: str) -> QIcon:
     """Return a themed QIcon or an empty icon if unavailable."""
     icon = QIcon.fromTheme(name)
     return icon if not icon.isNull() else QIcon()
+
+
+def get_notification_icon() -> QIcon:
+    """Return a non-null icon for tray notifications."""
+    icon = QIcon.fromTheme("dialog-information")
+    if icon.isNull():
+        px = QPixmap(1, 1)
+        px.fill(Qt.GlobalColor.transparent)
+        icon = QIcon(px)
+    return icon
+

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -614,7 +614,12 @@ class MainWindow(QMainWindow):
     def _show_notification(self, message: str, title: str = APP_NAME) -> None:
         icon = self._tray_icon
         if icon is None:
-            icon = QSystemTrayIcon(self.windowIcon(), self)
+            tray_icon = self.windowIcon()
+            if tray_icon.isNull():
+                from .icons import get_notification_icon
+
+                tray_icon = get_notification_icon()
+            icon = QSystemTrayIcon(tray_icon, self)
             self._tray_icon = icon
 
         icon.show()


### PR DESCRIPTION
## Summary
- ensure a non-null icon for system tray notifications
- fall back to a transparent icon if no theme icon is available

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`