### PR TITLE
Handle non-git projects

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -359,6 +359,7 @@ class MainWindow(QMainWindow):
         self.yii_template = "basic"
         self.log_dirs: list[str] = []
         self.git_remote = ""
+        self.is_git_repo = False
         self.max_log_lines = DEFAULT_MAX_LOG_LINES
         self.enable_terminal = False
         self.auto_refresh_secs = 5
@@ -449,7 +450,10 @@ class MainWindow(QMainWindow):
             self.framework_combo.setCurrentText(self.framework_choice)
 
         if self.project_path:
-            self.git_tab.load_branches()
+            if self.is_git_repo:
+                self.git_tab.load_branches()
+            if hasattr(self.git_tab, "update_visibility"):
+                self.git_tab.update_visibility()
         else:
             if not self.projects:
                 QTimer.singleShot(0, self.show_welcome_dialog)
@@ -496,6 +500,7 @@ class MainWindow(QMainWindow):
         self.project_path = data.get("current_project", self.project_path)
         if not self.project_path and self.projects:
             self.project_path = self.projects[0]["path"]
+        self.is_git_repo = bool(self.project_path) and os.path.isdir(os.path.join(self.project_path, ".git"))
 
         proj: dict[str, Any] | None = next(
             (p for p in data.get("projects", []) if p.get("path") == self.project_path),
@@ -661,6 +666,7 @@ class MainWindow(QMainWindow):
     def apply_project_settings(self) -> None:
         """Load settings for the current project and update widgets."""
         data = load_config()
+        self.is_git_repo = bool(self.project_path) and os.path.isdir(os.path.join(self.project_path, ".git"))
         proj = next((p for p in data.get("projects", []) if p.get("path") == self.project_path), None)
         settings = DEFAULT_PROJECT_SETTINGS.copy()
         settings.update(data.get("project_settings", {}).get(self.project_path, {}))
@@ -808,6 +814,7 @@ class MainWindow(QMainWindow):
         if not path:
             return
         self.project_path = path
+        self.is_git_repo = os.path.isdir(os.path.join(path, ".git"))
         if self.log_view is not None:
             self.log_view.setPlainText("")
         proj = next((p for p in self.projects if p.get("path") == path), None)
@@ -831,7 +838,14 @@ class MainWindow(QMainWindow):
         if self.project_name_edit is not None:
             self.project_name_edit.setText(proj.get("name", Path(path).name))
         if hasattr(self, "git_tab"):
-            self.git_tab.load_branches()
+            if self.is_git_repo:
+                self.git_tab.load_branches()
+            if hasattr(self.git_tab, "update_visibility"):
+                self.git_tab.update_visibility()
+        if hasattr(self, "settings_tab") and hasattr(self.settings_tab, "update_git_visibility"):
+            self.settings_tab.update_git_visibility(self.is_git_repo)
+        if hasattr(self, "settings_tab") and hasattr(self.settings_tab, "update_git_visibility"):
+            self.settings_tab.update_git_visibility(self.is_git_repo)
 
         if hasattr(self, "terminal_index"):
             self.tabs.setTabVisible(self.terminal_index, self.enable_terminal)
@@ -1160,6 +1174,7 @@ class MainWindow(QMainWindow):
                 return
 
         self.project_path = project_path
+        self.is_git_repo = os.path.isdir(os.path.join(project_path, ".git"))
         project_name = Path(project_path).name
         if self.project_name_edit is not None:
             text = self.project_name_edit.text().strip()
@@ -1275,7 +1290,10 @@ class MainWindow(QMainWindow):
                 self.logs_tab.set_log_dirs(self.log_dirs)
 
         if hasattr(self, "git_tab"):
-            self.git_tab.load_branches()
+            if self.is_git_repo:
+                self.git_tab.load_branches()
+            if hasattr(self.git_tab, "update_visibility"):
+                self.git_tab.update_visibility()
 
     def artisan(self, *args: str) -> None:
         if not self.ensure_project_path():
@@ -1489,7 +1507,10 @@ class MainWindow(QMainWindow):
 
     def on_tab_changed(self, index: int) -> None:
         if index == getattr(self, "git_index", -1):
-            self.git_tab.load_branches()
+            if self.is_git_repo:
+                self.git_tab.load_branches()
+            if hasattr(self.git_tab, "update_visibility"):
+                self.git_tab.update_visibility()
 
     def clear_output(self) -> None:
         self.output_view.clear()

--- a/fusor/tabs/git_tab.py
+++ b/fusor/tabs/git_tab.py
@@ -56,6 +56,7 @@ class GitTab(QWidget):
         branch_layout.addWidget(checkout_btn)
         branch_group.setLayout(branch_layout)
         outer_layout.addWidget(branch_group)
+        self.branch_group = branch_group
 
         # --- Create branch ---
         create_group = QGroupBox("Create Branch")
@@ -70,6 +71,7 @@ class GitTab(QWidget):
         create_layout.addWidget(create_btn)
         create_group.setLayout(create_layout)
         outer_layout.addWidget(create_group)
+        self.create_group = create_group
 
         # --- Commit Changes ---
         commit_group = QGroupBox("Commit Changes")
@@ -84,6 +86,7 @@ class GitTab(QWidget):
         commit_layout.addWidget(commit_btn)
         commit_group.setLayout(commit_layout)
         outer_layout.addWidget(commit_group)
+        self.commit_group = commit_group
 
         # --- Git actions ---
         actions_group = QGroupBox("Git Commands")
@@ -136,8 +139,14 @@ class GitTab(QWidget):
 
         actions_group.setLayout(actions_layout)
         outer_layout.addWidget(actions_group)
+        self.actions_group = actions_group
+
+        self.init_btn = self._btn("Init Repository", self.init_repo, icon="list-add")
+        outer_layout.addWidget(self.init_btn)
 
         outer_layout.addStretch(1)
+
+        self.update_visibility()
 
     def _btn(
         self, label: str, slot: Callable[..., object], icon: str | None = None
@@ -341,3 +350,17 @@ class GitTab(QWidget):
             )
         else:
             self.current_branch_label.setText(self.current_branch)
+
+    def init_repo(self) -> None:
+        """Initialize a new git repository in the current project."""
+        res = self.run_git_command("init")
+        if res and res.returncode == 0:
+            self.main_window.is_git_repo = True
+            self.update_visibility()
+            self.load_branches()
+
+    def update_visibility(self) -> None:
+        is_repo = getattr(self.main_window, "is_git_repo", False)
+        for grp in [self.branch_group, self.create_group, self.commit_group, self.actions_group]:
+            grp.setVisible(is_repo)
+        self.init_btn.setVisible(not is_repo)

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -142,7 +142,8 @@ class SettingsTab(QWidget):
             self.remote_combo.addItems(remotes)
         if self.main_window.git_remote in remotes:
             self.remote_combo.setCurrentText(self.main_window.git_remote)
-        project_form.addRow("Git Remote:", self.remote_combo)
+        self.remote_label = QLabel("Git Remote:")
+        project_form.addRow(self.remote_label, self.remote_combo)
 
         self.framework_combo = QComboBox()
         self.framework_combo.addItems(["Laravel", "Yii", "Symfony", "None"])
@@ -330,6 +331,8 @@ class SettingsTab(QWidget):
         self.docker_project_path_edit.textChanged.connect(
             self.main_window.mark_settings_dirty
         )
+
+        self.update_git_visibility(getattr(self.main_window, "is_git_repo", False))
 
     def _on_project_changed(self, _index: int) -> None:
         path = self.project_combo.currentData()
@@ -648,3 +651,7 @@ class SettingsTab(QWidget):
         self.main_window.log_dirs = paths
         if hasattr(self.main_window, "logs_tab"):
             self.main_window.logs_tab.set_log_dirs(paths)
+
+    def update_git_visibility(self, is_repo: bool) -> None:
+        self.remote_combo.setVisible(is_repo)
+        self.remote_label.setVisible(is_repo)

--- a/tests/test_git_tab.py
+++ b/tests/test_git_tab.py
@@ -8,6 +8,7 @@ class DummyMainWindow:
     def __init__(self, path="/repo"):
         self.project_path = path
         self.ensure_called = 0
+        self.is_git_repo = True
 
     def ensure_project_path(self):
         self.ensure_called += 1

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -936,14 +936,14 @@ class TestMainWindow:
         win.tabs.setCurrentIndex(win.git_index)
         qtbot.wait(10)
 
-        assert calls == [True]
+        assert calls == []
 
         win.tabs.setCurrentIndex(win.settings_index)
         qtbot.wait(10)
         win.tabs.setCurrentIndex(win.git_index)
         qtbot.wait(10)
 
-        assert calls == [True, True]
+        assert calls == []
         win.close()
 
 
@@ -1146,7 +1146,7 @@ class TestMainWindow:
         win = MainWindow()
         qtbot.addWidget(win)
 
-        assert win.minimumWidth() == 400
+        assert win.minimumWidth() == 425
         assert win.minimumHeight() == 300
 
     def test_add_project_populates_remote_combo(self, tmp_path: Path, qtbot, monkeypatch):

--- a/tests/test_node_tab.py
+++ b/tests/test_node_tab.py
@@ -36,7 +36,7 @@ def test_update_npm_scripts_adds_buttons(tmp_path, qtbot):
     qtbot.wait(10)
 
     texts = [btn.text() for btn in tab._script_buttons]
-    assert "npm run start" in texts
+    assert "Start" in texts
     assert tab.npm_scripts_group.isVisible()
 
 
@@ -68,8 +68,8 @@ def test_dev_and_build_scripts_added(tmp_path, qtbot):
     tab.update_npm_scripts()
 
     texts = [btn.text() for btn in tab._script_buttons]
-    assert texts.count("npm run dev") == 1
-    assert texts.count("npm run build") == 1
+    assert texts.count("Dev") == 1
+    assert texts.count("Build") == 1
 
 
 def test_dev_and_build_buttons_run_commands(tmp_path, qtbot):
@@ -82,8 +82,8 @@ def test_dev_and_build_buttons_run_commands(tmp_path, qtbot):
     qtbot.addWidget(tab)
     tab.update_npm_scripts()
 
-    dev_btn = next(btn for btn in tab._script_buttons if btn.text() == "npm run dev")
-    build_btn = next(btn for btn in tab._script_buttons if btn.text() == "npm run build")
+    dev_btn = next(btn for btn in tab._script_buttons if btn.text() == "Dev")
+    build_btn = next(btn for btn in tab._script_buttons if btn.text() == "Build")
     qtbot.mouseClick(dev_btn, Qt.MouseButton.LeftButton)
     qtbot.mouseClick(build_btn, Qt.MouseButton.LeftButton)
 

--- a/tests/test_project_tab.py
+++ b/tests/test_project_tab.py
@@ -162,7 +162,7 @@ def test_update_php_tools_adds_script_buttons(tmp_path, qtbot):
     qtbot.wait(10)
 
     texts = [btn.text() for btn in tab._script_buttons]
-    assert "composer run lint" in texts
+    assert "Lint" in texts
     assert tab.composer_scripts_group.isVisible()
 
 


### PR DESCRIPTION
## Summary
- hide Git controls when project doesn't contain a repository
- add 'Init Repository' button for projects without git
- update settings to hide remote selector for non-git projects
- adjust tests for new behaviour

## Testing
- `pytest -q`