### PR TITLE
Add port check before starting server

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -63,6 +63,7 @@ from .tabs.settings_tab import SettingsTab
 # allow tests to monkeypatch file operations easily
 open = builtins.open
 
+
 def _port_in_use(port: int) -> bool:
     """Return True if ``port`` is already bound on localhost."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -71,6 +72,7 @@ def _port_in_use(port: int) -> bool:
         except OSError:
             return True
     return False
+
 
 DARK_STYLESHEET = """
     QMainWindow {

--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -7,6 +7,7 @@ import concurrent.futures
 import builtins
 import shutil
 import webbrowser
+import socket
 from PyQt6.QtWidgets import (
     QMainWindow,
     QTabWidget,
@@ -61,6 +62,15 @@ from .tabs.settings_tab import SettingsTab
 
 # allow tests to monkeypatch file operations easily
 open = builtins.open
+
+def _port_in_use(port: int) -> bool:
+    """Return True if ``port`` is already bound on localhost."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind(("localhost", port))
+        except OSError:
+            return True
+    return False
 
 DARK_STYLESHEET = """
     QMainWindow {
@@ -1406,6 +1416,14 @@ class MainWindow(QMainWindow):
             return
 
         if not self.ensure_project_path():
+            return
+
+        if _port_in_use(self.server_port):
+            QMessageBox.warning(
+                self,
+                APP_NAME,
+                f"Port {self.server_port} is already in use.",
+            )
             return
 
         if self.current_framework() == "Laravel":


### PR DESCRIPTION
## Summary
- detect if the configured port is busy before launching the PHP server
- warn the user when the port is unavailable
- test port check logic

## Testing
- `ruff check .`
- `flake8 fusor`
- `mypy fusor`
- `pytest -q`