### PR TITLE
Add system tray icon

### DIFF
--- a/fusor/config.py
+++ b/fusor/config.py
@@ -39,6 +39,7 @@ DEFAULT_CONFIG = {
     "current_project": "",
     "theme": "dark",
     "show_console_output": False,
+    "enable_tray": False,
     # Window geometry (width, height) and position (x, y)
     "window_size": [1024, 768],
     "window_position": [100, 100],

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -225,6 +225,11 @@ class SettingsTab(QWidget):
             )
         misc_form.addRow("", self.console_output_checkbox)
 
+        self.tray_checkbox = QCheckBox("Enable System Tray Icon")
+        if hasattr(self.main_window, "tray_enabled"):
+            self.tray_checkbox.setChecked(self.main_window.tray_enabled)
+        misc_form.addRow("", self.tray_checkbox)
+
         self.yii_template_combo = QComboBox()
         self.yii_template_combo.addItems(["basic", "advanced"])
         if hasattr(self.main_window, "yii_template"):
@@ -239,6 +244,7 @@ class SettingsTab(QWidget):
         self.docker_checkbox.toggled.connect(self.on_docker_toggled)
         self.terminal_checkbox.toggled.connect(self.on_terminal_toggled)
         self.console_output_checkbox.toggled.connect(self.on_console_output_toggled)
+        self.tray_checkbox.toggled.connect(self.on_tray_toggled)
         docker_form.addRow("", self.docker_checkbox)
 
         project_group.setLayout(project_form)
@@ -281,10 +287,12 @@ class SettingsTab(QWidget):
         self.main_window.terminal_checkbox = self.terminal_checkbox
         self.main_window.open_browser_checkbox = self.open_browser_checkbox
         self.main_window.console_output_checkbox = self.console_output_checkbox
+        self.main_window.tray_checkbox = self.tray_checkbox
 
         self.on_docker_toggled(self.docker_checkbox.isChecked())
         self.on_terminal_toggled(self.terminal_checkbox.isChecked())
         self.on_console_output_toggled(self.console_output_checkbox.isChecked())
+        self.on_tray_toggled(self.tray_checkbox.isChecked())
         current_fw = self.framework_combo.currentText()
         self.on_framework_changed(current_fw)
         self.main_window.database_tab.on_framework_changed(current_fw)
@@ -322,6 +330,9 @@ class SettingsTab(QWidget):
             self.main_window.mark_settings_dirty
         )
         self.console_output_checkbox.toggled.connect(
+            self.main_window.mark_settings_dirty
+        )
+        self.tray_checkbox.toggled.connect(
             self.main_window.mark_settings_dirty
         )
         self.project_name_edit.textChanged.connect(self.main_window.mark_settings_dirty)
@@ -491,6 +502,13 @@ class SettingsTab(QWidget):
         if hasattr(self.main_window, "output_view"):
             self.main_window.show_console_output = checked
             self.main_window._update_responsive_layout()
+
+    def on_tray_toggled(self, checked: bool) -> None:
+        self.main_window.tray_enabled = checked
+        if checked:
+            self.main_window._init_tray_icon()
+        elif self.main_window._tray_icon is not None:
+            self.main_window._tray_icon.hide()
 
     def add_project(self) -> None:
         directory = QFileDialog.getExistingDirectory(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,6 +31,7 @@ def test_save_then_load(tmp_path, monkeypatch):
     config.save_config(data)
     loaded = config.load_config()
     data.setdefault("show_console_output", False)
+    data.setdefault("enable_tray", False)
     assert loaded == data
 
 def test_load_missing_file(tmp_path, monkeypatch):

--- a/tests/test_settings_tab.py
+++ b/tests/test_settings_tab.py
@@ -21,6 +21,8 @@ class DummyMainWindow:
         self.theme = "dark"
         self.git_remote = ""
         self.enable_terminal = False
+        self.tray_enabled = False
+        self._tray_icon = None
         self.git_tab = type("G", (), {"get_remotes": lambda self: []})()
         self.database_tab = type("D", (), {"on_framework_changed": lambda self, t: None})()
         self.mark_settings_dirty = lambda *a, **k: None


### PR DESCRIPTION
## Summary
- support enabling system tray icon from Settings
- persist tray icon state in config
- show system tray icon with Show/Hide, Start/Stop and Quit actions
- update tests for tray icon feature

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687deaa017a083228b8e91fc9eb0acee