### PR TITLE
Fix project creation path check

### DIFF
--- a/fusor/welcome_dialog.py
+++ b/fusor/welcome_dialog.py
@@ -100,10 +100,12 @@ class WelcomeDialog(QDialog):
         if getattr(self.main_window, "framework_combo", None):
             self.main_window.framework_combo.setCurrentText(fw)
 
-        self.main_window.run_command(cmd)
-        self.main_window.set_current_project(str(dest))
-        self.main_window.save_settings()
-        self.accept()
+        def finalize() -> None:
+            self.main_window.set_current_project(str(dest))
+            self.main_window.save_settings()
+            self.accept()
+
+        self.main_window.run_command(cmd, callback=finalize)
 
     def clone_project(self) -> None:
         url, ok = QInputDialog.getText(self, "Clone from Git", "Repository URL:")

--- a/tests/test_welcome_dialog.py
+++ b/tests/test_welcome_dialog.py
@@ -17,8 +17,10 @@ class DummyMainWindow(QWidget):
     def save_settings(self):
         self.saved = True
 
-    def run_command(self, cmd):
+    def run_command(self, cmd, callback=None):
         self.cmd = cmd
+        if callback:
+            callback()
 
 
 def test_create_project_laravel(monkeypatch, qtbot, tmp_path):


### PR DESCRIPTION
## Summary
- defer saving new project settings until creation command finishes
- return `Future` from `run_command` and allow callback
- adapt tests for asynchronous behavior

## Testing
- `pytest -q`