### PR TITLE
Fix framework detection after project creation

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -544,6 +544,7 @@ class MainWindow(QMainWindow):
             None,
         )
         settings: dict[str, Any] = DEFAULT_PROJECT_SETTINGS.copy()
+        settings["framework"] = self.framework_choice
         settings.update(data.get("project_settings", {}).get(self.project_path, {}))
         if isinstance(proj, dict):
             temp = proj.copy()
@@ -759,6 +760,7 @@ class MainWindow(QMainWindow):
         self.is_git_repo = bool(self.project_path) and os.path.isdir(os.path.join(self.project_path, ".git"))
         proj = next((p for p in data.get("projects", []) if p.get("path") == self.project_path), None)
         settings = DEFAULT_PROJECT_SETTINGS.copy()
+        settings["framework"] = self.framework_choice
         settings.update(data.get("project_settings", {}).get(self.project_path, {}))
         if isinstance(proj, dict):
             temp = proj.copy()

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -292,6 +292,14 @@ class TestMainWindow:
         assert main_window.tabs.isTabVisible(main_window.node_index)
         assert main_window.tabs.isTabEnabled(main_window.node_index)
 
+    def test_set_current_project_preserves_framework_choice(self, tmp_path: Path, main_window, qtbot):
+        main_window.framework_choice = "Symfony"
+        main_window.framework_combo.setCurrentText("Symfony")
+        main_window.set_current_project(str(tmp_path))
+        qtbot.wait(10)
+        assert main_window.framework_choice == "Symfony"
+        assert main_window.framework_combo.currentText() == "Symfony"
+
     def test_composer_install_button_runs_command(self, main_window, qtbot, monkeypatch):
         captured = []
         monkeypatch.setattr(main_window, "run_command", lambda cmd: captured.append(cmd), raising=True)


### PR DESCRIPTION
## Summary
- preserve selected framework when switching projects
- test that set_current_project keeps the chosen framework

## Testing
- `ruff check .`
- `mypy .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e42ed4c9c83229ef7bbc26956ab51