### PR TITLE
Add progress dialog and ensure finalize callback

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -282,10 +282,12 @@ def apply_theme(widget: QMainWindow, theme: str) -> None:
 
 class MainWindow(QMainWindow):
     notify_signal = pyqtSignal(str, str)
+    call_later = pyqtSignal(object)
 
     def __init__(self):
         super().__init__()
         self.notify_signal.connect(self._show_notification)
+        self.call_later.connect(lambda f: f())
         self.setWindowTitle(f"{APP_NAME} – PHP QA Toolbox")
         self.resize(1024, 768)
         self.setMinimumSize(425, 300)
@@ -902,7 +904,8 @@ class MainWindow(QMainWindow):
                 self.notify(f"Command not found: {command[0]}")
             finally:
                 if callback is not None:
-                    QTimer.singleShot(0, callback)
+                    # ensure callback runs on the UI thread
+                    self.call_later.emit(callback)
 
         print(f"$ {' '.join(command)}")
         return self.executor.submit(task)

--- a/fusor/welcome_dialog.py
+++ b/fusor/welcome_dialog.py
@@ -11,7 +11,10 @@ from PyQt6.QtWidgets import (
     QFileDialog,
     QInputDialog,
     QMessageBox,
+    QProgressDialog,
 )
+from PyQt6.QtCore import Qt
+from typing import Optional
 
 from . import APP_NAME
 
@@ -23,6 +26,7 @@ class WelcomeDialog(QDialog):
         super().__init__(main_window)
         self.main_window = main_window
         self.setWindowTitle(f"Welcome to {APP_NAME}")
+        self.progress_dialog: Optional[QProgressDialog] = None
 
         layout = QVBoxLayout(self)
         layout.addWidget(QLabel("Select a project to get started:"))
@@ -102,8 +106,19 @@ class WelcomeDialog(QDialog):
 
         self.setDisabled(True)
         self.main_window.setDisabled(True)
+        dlg = QProgressDialog("Creating project...", None, 0, 0, self)
+        dlg.setWindowTitle("Please Wait")
+        dlg.setWindowModality(Qt.WindowModality.WindowModal)
+        dlg.setMinimumDuration(0)
+        dlg.setAutoClose(False)
+        dlg.show()
+        self.progress_dialog = dlg
 
         def finalize() -> None:
+            if self.progress_dialog is not None:
+                self.progress_dialog.hide()
+                self.progress_dialog.deleteLater()
+                self.progress_dialog = None
             self.main_window.set_current_project(str(dest))
             self.main_window.save_settings()
             self.main_window.setDisabled(False)


### PR DESCRIPTION
## Summary
- add `call_later` signal for main thread callbacks
- use `call_later` from `run_command`
- show a `QProgressDialog` while a project is being created

## Testing
- `ruff check .`
- `flake8`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e4f66fc6c8322a558113dd1c76174