### PR TITLE
Remove project name input field

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -295,7 +295,6 @@ class MainWindow(QMainWindow):
 
         # Widgets populated by SettingsTab and LogsTab
         self.project_combo: QComboBox | None = None
-        self.project_name_edit: QLineEdit | None = None
         self.framework_combo: QComboBox | None = None
         self.php_path_edit: QLineEdit | None = None
         self.php_service_edit: QLineEdit | None = None
@@ -942,8 +941,6 @@ class MainWindow(QMainWindow):
             else:
                 self.project_combo.setCurrentText(proj["name"])
             self.project_combo.blockSignals(False)
-        if self.project_name_edit is not None:
-            self.project_name_edit.setText(proj.get("name", Path(path).name))
         if hasattr(self, "git_tab"):
             if self.is_git_repo:
                 self.git_tab.load_branches()
@@ -1299,10 +1296,12 @@ class MainWindow(QMainWindow):
         self.project_path = project_path
         self.is_git_repo = os.path.isdir(os.path.join(project_path, ".git"))
         project_name = Path(project_path).name
-        if self.project_name_edit is not None:
-            text = self.project_name_edit.text().strip()
-            if text:
-                project_name = text
+        if self.project_combo is not None:
+            idx = self.project_combo.findData(project_path)
+            if idx >= 0:
+                text = self.project_combo.itemText(idx).strip()
+                if text:
+                    project_name = text
         existing = next(
             (p for p in self.projects if p.get("path") == project_path), None
         )

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -80,14 +80,6 @@ class SettingsTab(QWidget):
         project_row.addWidget(rename_btn)
         project_form.addRow(project_row)
 
-        self.project_name_edit = QLineEdit()
-        name = ""
-        for p in self.main_window.projects:
-            if p.get("path") == self.main_window.project_path:
-                name = p.get("name", "")
-                break
-        self.project_name_edit.setText(name)
-        project_form.addRow("Project Name:", self.project_name_edit)
 
         self.php_path_edit = QLineEdit(self.main_window.php_path)
         self.php_browse_btn = QPushButton("")
@@ -276,7 +268,6 @@ class SettingsTab(QWidget):
         outer_layout.addWidget(save_btn, alignment=Qt.AlignmentFlag.AlignCenter)
 
         self.main_window.project_combo = self.project_combo
-        self.main_window.project_name_edit = self.project_name_edit
         self.main_window.framework_combo = self.framework_combo
         self.main_window.php_path_edit = self.php_path_edit
         self.main_window.php_service_edit = self.php_service_edit
@@ -342,7 +333,6 @@ class SettingsTab(QWidget):
         self.tray_checkbox.toggled.connect(
             self.main_window.mark_settings_dirty
         )
-        self.project_name_edit.textChanged.connect(self.main_window.mark_settings_dirty)
         self.compose_profile_edit.textChanged.connect(
             self.main_window.mark_settings_dirty
         )
@@ -355,14 +345,6 @@ class SettingsTab(QWidget):
     def _on_project_changed(self, _index: int) -> None:
         path = self.project_combo.currentData()
         self.main_window.set_current_project(path)
-        name = ""
-        for p in self.main_window.projects:
-            if p.get("path") == path:
-                name = p.get("name", os.path.basename(path))
-                break
-        self.project_name_edit.blockSignals(True)
-        self.project_name_edit.setText(name)
-        self.project_name_edit.blockSignals(False)
 
     def _wrap(self, child: Union[QLayout, QWidget]) -> QWidget:
         """Return a QWidget containing the given layout or widget."""
@@ -612,7 +594,6 @@ class SettingsTab(QWidget):
             return
         new_name = new_name.strip()
         self.project_combo.setItemText(index, new_name)
-        self.project_name_edit.setText(new_name)
         path = self.project_combo.itemData(index)
         for p in self.main_window.projects:
             if p.get("path") == path:

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -1087,8 +1087,8 @@ class TestMainWindow:
     def test_save_settings_updates_project_name(self, main_window, monkeypatch):
         main_window.project_combo.addItem("/tmp", "/tmp")
         main_window.project_combo.setCurrentIndex(0)
+        main_window.project_combo.setItemText(0, "MyProj")
         main_window.project_path = "/tmp"
-        main_window.project_name_edit.setText("MyProj")
         main_window.php_path_edit.setText("php")
         main_window.docker_checkbox.setChecked(False)
         main_window.server_port_edit.setValue(8000)


### PR DESCRIPTION
## Summary
- remove project name QLineEdit from settings tab
- adjust logic in MainWindow to read name from combo box
- update tests accordingly

## Testing
- `ruff check .`
- `pytest -q`