### PR TITLE
Add Composer tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,14 @@ Fusor aims to **simplify routine PHP project operations** via a user-friendly vi
 
 | Tab          | Description                                                                                    |
 | ------------ | ---------------------------------------------------------------------------------------------- |
-| **Project**  | Start/stop server, Composer install/update, PHP tools (PHPUnit, Rector, CS-Fixer)              |
+| **Project**  | Start/stop server and PHP tools (PHPUnit, Rector, CS-Fixer)                                     |
 | **Git**      | Switch branches, view status or diff, pull, hard reset, stash changes                          |
 | **Database** | Dump or restore SQL, run migrations, seed data                                                 |
 | **Laravel**  | Migrate, rollback, fresh seed, and other artisan helpers _(visible when framework is Laravel)_ |
 | **Symfony**  | Clear cache and manage Doctrine migrations _(visible when framework is Symfony)_               |
 | **Yii**      | Common Yii console commands _(visible when framework is Yii)_                                  |
 | **Docker**   | Build, pull, restart services, inspect containers _(visible only in Docker mode)_              |
+| **Composer** | Run composer install/update and scripts                                               |
 | **Node**     | Run npm install and package scripts (e.g., dev, build)                                         |
 | **Logs**     | View logs with optional auto-refresh and open log files in your default application            |
 | **.env**     | Edit the project's environment file                                                            |

--- a/fusor/tabs/__init__.py
+++ b/fusor/tabs/__init__.py
@@ -2,5 +2,6 @@ from .symfony_tab import SymfonyTab
 from .yii_tab import YiiTab
 from .env_tab import EnvTab
 from .node_tab import NodeTab
+from .composer_tab import ComposerTab
 
-__all__ = ["SymfonyTab", "YiiTab", "EnvTab", "NodeTab"]
+__all__ = ["SymfonyTab", "YiiTab", "EnvTab", "NodeTab", "ComposerTab"]

--- a/fusor/tabs/composer_tab.py
+++ b/fusor/tabs/composer_tab.py
@@ -1,0 +1,103 @@
+from PyQt6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QPushButton,
+    QSizePolicy,
+    QScrollArea,
+    QGroupBox,
+)
+from typing import Callable
+from pathlib import Path
+import json
+
+from ..icons import get_icon
+
+
+class ComposerTab(QWidget):
+    """Helpers for composer based workflows."""
+
+    def __init__(self, main_window):
+        super().__init__()
+        self.main_window = main_window
+
+        main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        main_layout.addWidget(scroll)
+
+        container = QWidget()
+        scroll.setWidget(container)
+
+        layout = QVBoxLayout(container)
+        layout.setContentsMargins(20, 20, 20, 20)
+        layout.setSpacing(12)
+
+        self.install_btn = self._btn(
+            "Composer install", self.composer_install, icon="package-install"
+        )
+        self.update_btn = self._btn(
+            "Composer update", self.composer_update, icon="system-software-update"
+        )
+        layout.addWidget(self.install_btn)
+        layout.addWidget(self.update_btn)
+
+        self.scripts_group = QGroupBox("Composer Scripts")
+        self.scripts_layout = QVBoxLayout()
+        self.scripts_group.setLayout(self.scripts_layout)
+        layout.addWidget(self.scripts_group)
+
+        layout.addStretch(1)
+
+        self.update_composer_scripts()
+
+    def _btn(self, text: str, slot: Callable[[], None], icon: str | None = None) -> QPushButton:
+        btn = QPushButton(text)
+        if icon:
+            btn.setIcon(get_icon(icon))
+        btn.setMinimumHeight(36)
+        btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        btn.clicked.connect(slot)
+        return btn
+
+    def composer_install(self) -> None:
+        self.main_window.run_command(["composer", "install"])
+
+    def composer_update(self) -> None:
+        self.main_window.run_command(["composer", "update"])
+
+    def update_composer_scripts(self) -> None:
+        scripts: list[str] = []
+        path = self.main_window.project_path
+        if path:
+            composer = Path(path) / "composer.json"
+            try:
+                with open(composer, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                scr = data.get("scripts", {})
+                if isinstance(scr, dict):
+                    scripts = list(scr.keys())
+            except OSError:
+                pass
+
+        for btn in getattr(self, "_script_buttons", []):
+            self.scripts_layout.removeWidget(btn)
+            btn.deleteLater()
+        self._script_buttons = []
+
+        for name in scripts:
+            btn = self._btn(
+                name.capitalize().replace('-', ' '),
+                lambda _=False, n=name: self.main_window.run_command([
+                    "composer",
+                    "run",
+                    n,
+                ]),
+                icon="system-run",
+            )
+            self.scripts_layout.addWidget(btn)
+            self._script_buttons.append(btn)
+
+        self.scripts_group.setVisible(bool(scripts))
+

--- a/fusor/tabs/project_tab.py
+++ b/fusor/tabs/project_tab.py
@@ -102,28 +102,6 @@ class ProjectTab(QWidget):
         self.php_tools_group.setLayout(php_layout)
         layout.addWidget(self.php_tools_group)
 
-        composer_group = QGroupBox("Composer")
-        composer_layout = QVBoxLayout()
-        self.composer_install_btn = self._btn(
-            "Composer install",
-            lambda: main_window.run_command(["composer", "install"]),
-            icon="package-install",
-        )
-        self.composer_update_btn = self._btn(
-            "Composer update",
-            lambda: main_window.run_command(["composer", "update"]),
-            icon="system-software-update",
-        )
-        composer_layout.addWidget(self.composer_install_btn)
-        composer_layout.addWidget(self.composer_update_btn)
-        composer_group.setLayout(composer_layout)
-        layout.addWidget(composer_group)
-
-        # --- Composer Scripts ---
-        self.composer_scripts_group = QGroupBox("Composer Scripts")
-        self.composer_scripts_layout = QVBoxLayout()
-        self.composer_scripts_group.setLayout(self.composer_scripts_layout)
-        layout.addWidget(self.composer_scripts_group)
 
         layout.addStretch(1)
 
@@ -184,7 +162,6 @@ class ProjectTab(QWidget):
     def update_php_tools(self) -> None:
         """Enable or disable PHP tool buttons based on composer.json."""
         packages: set[str] = set()
-        scripts: list[str] = []
         path = self.main_window.project_path
         if path:
             composer = Path(path) / "composer.json"
@@ -195,9 +172,6 @@ class ProjectTab(QWidget):
                     pkgs = data.get(key, {})
                     if isinstance(pkgs, dict):
                         packages.update(pkgs.keys())
-                scr = data.get("scripts", {})
-                if isinstance(scr, dict):
-                    scripts = list(scr.keys())
             except OSError:
                 pass
 
@@ -209,23 +183,3 @@ class ProjectTab(QWidget):
         for pkg, btn in mapping.items():
             btn.setEnabled(pkg in packages)
 
-        # --- Composer scripts ---
-        for btn in getattr(self, "_script_buttons", []):
-            self.composer_scripts_layout.removeWidget(btn)
-            btn.deleteLater()
-        self._script_buttons = []
-
-        for name in scripts:
-            btn = self._btn(
-                name.capitalize().replace('-', ' '),
-                lambda _=False, n=name: self.main_window.run_command([
-                    "composer",
-                    "run",
-                    n,
-                ]),
-                icon="system-run",
-            )
-            self.composer_scripts_layout.addWidget(btn)
-            self._script_buttons.append(btn)
-
-        self.composer_scripts_group.setVisible(bool(scripts))

--- a/tests/test_composer_tab.py
+++ b/tests/test_composer_tab.py
@@ -1,0 +1,61 @@
+import json
+from PyQt6.QtCore import Qt
+
+import json
+from PyQt6.QtCore import Qt
+
+from fusor.tabs.composer_tab import ComposerTab
+
+
+class DummyMainWindow:
+    def __init__(self):
+        self.project_path = ""
+        self.commands = []
+
+    def run_command(self, cmd):
+        self.commands.append(cmd)
+
+
+def test_buttons_run_commands(qtbot):
+    main = DummyMainWindow()
+    tab = ComposerTab(main)
+    qtbot.addWidget(tab)
+
+    qtbot.mouseClick(tab.install_btn, Qt.MouseButton.LeftButton)
+    qtbot.mouseClick(tab.update_btn, Qt.MouseButton.LeftButton)
+
+    assert main.commands == [["composer", "install"], ["composer", "update"]]
+
+
+def test_update_composer_scripts_adds_buttons(tmp_path, qtbot):
+    data = {"scripts": {"lint": "phpcs"}}
+    (tmp_path / "composer.json").write_text(json.dumps(data))
+
+    main = DummyMainWindow()
+    main.project_path = str(tmp_path)
+    tab = ComposerTab(main)
+    qtbot.addWidget(tab)
+    tab.update_composer_scripts()
+    tab.show()
+    qtbot.wait(10)
+
+    texts = [btn.text() for btn in tab._script_buttons]
+    assert "Lint" in texts
+    assert tab.scripts_group.isVisible()
+
+
+def test_script_button_runs_command(tmp_path, qtbot, monkeypatch):
+    data = {"scripts": {"lint": "phpcs"}}
+    (tmp_path / "composer.json").write_text(json.dumps(data))
+
+    main = DummyMainWindow()
+    main.project_path = str(tmp_path)
+    captured = []
+    monkeypatch.setattr(main, "run_command", lambda cmd: captured.append(cmd), raising=True)
+    tab = ComposerTab(main)
+    qtbot.addWidget(tab)
+    tab.update_composer_scripts()
+    btn = tab._script_buttons[0]
+    qtbot.mouseClick(btn, Qt.MouseButton.LeftButton)
+
+    assert captured == [["composer", "run", "lint"]]

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -292,6 +292,18 @@ class TestMainWindow:
         assert main_window.tabs.isTabVisible(main_window.node_index)
         assert main_window.tabs.isTabEnabled(main_window.node_index)
 
+    def test_composer_tab_visibility(self, tmp_path: Path, main_window, qtbot):
+        main_window.set_current_project(str(tmp_path))
+        qtbot.wait(10)
+        assert not main_window.tabs.isTabVisible(main_window.composer_index)
+        assert not main_window.tabs.isTabEnabled(main_window.composer_index)
+
+        (tmp_path / "composer.json").write_text("{}")
+        main_window.set_current_project(str(tmp_path))
+        qtbot.wait(10)
+        assert main_window.tabs.isTabVisible(main_window.composer_index)
+        assert main_window.tabs.isTabEnabled(main_window.composer_index)
+
     def test_set_current_project_preserves_framework_choice(self, tmp_path: Path, main_window, qtbot):
         main_window.framework_choice = "Symfony"
         main_window.framework_combo.setCurrentText("Symfony")
@@ -300,16 +312,20 @@ class TestMainWindow:
         assert main_window.framework_choice == "Symfony"
         assert main_window.framework_combo.currentText() == "Symfony"
 
-    def test_composer_install_button_runs_command(self, main_window, qtbot, monkeypatch):
+    def test_composer_install_button_runs_command(self, tmp_path: Path, main_window, qtbot, monkeypatch):
         captured = []
         monkeypatch.setattr(main_window, "run_command", lambda cmd: captured.append(cmd), raising=True)
-        qtbot.mouseClick(main_window.project_tab.composer_install_btn, Qt.MouseButton.LeftButton)
+        (tmp_path / "composer.json").write_text("{}")
+        main_window.set_current_project(str(tmp_path))
+        qtbot.mouseClick(main_window.composer_tab.install_btn, Qt.MouseButton.LeftButton)
         assert captured == [["composer", "install"]]
 
-    def test_composer_update_button_runs_command(self, main_window, qtbot, monkeypatch):
+    def test_composer_update_button_runs_command(self, tmp_path: Path, main_window, qtbot, monkeypatch):
         captured = []
         monkeypatch.setattr(main_window, "run_command", lambda cmd: captured.append(cmd), raising=True)
-        qtbot.mouseClick(main_window.project_tab.composer_update_btn, Qt.MouseButton.LeftButton)
+        (tmp_path / "composer.json").write_text("{}")
+        main_window.set_current_project(str(tmp_path))
+        qtbot.mouseClick(main_window.composer_tab.update_btn, Qt.MouseButton.LeftButton)
         assert captured == [["composer", "update"]]
 
     def test_run_command_uses_php_service_with_docker(self, main_window, monkeypatch):

--- a/tests/test_project_tab.py
+++ b/tests/test_project_tab.py
@@ -2,7 +2,6 @@ import os
 import sys
 import subprocess
 import json
-from PyQt6.QtCore import Qt
 
 from fusor.tabs.project_tab import ProjectTab
 
@@ -151,31 +150,3 @@ def test_update_php_tools_disable_without_composer(tmp_path, qtbot):
     assert not tab.csfixer_btn.isEnabled()
 
 
-def test_update_php_tools_adds_script_buttons(tmp_path, qtbot):
-    data = {"scripts": {"lint": "phpcs"}}
-    (tmp_path / "composer.json").write_text(json.dumps(data))
-
-    tab, main = make_tab(qtbot)
-    main.project_path = str(tmp_path)
-    tab.update_php_tools()
-    tab.show()
-    qtbot.wait(10)
-
-    texts = [btn.text() for btn in tab._script_buttons]
-    assert "Lint" in texts
-    assert tab.composer_scripts_group.isVisible()
-
-
-def test_script_button_runs_command(tmp_path, qtbot, monkeypatch):
-    data = {"scripts": {"lint": "phpcs"}}
-    (tmp_path / "composer.json").write_text(json.dumps(data))
-
-    tab, main = make_tab(qtbot)
-    main.project_path = str(tmp_path)
-    captured = []
-    monkeypatch.setattr(main, "run_command", lambda cmd: captured.append(cmd), raising=True)
-    tab.update_php_tools()
-    btn = tab._script_buttons[0]
-    qtbot.mouseClick(btn, Qt.MouseButton.LeftButton)
-
-    assert captured == [["composer", "run", "lint"]]


### PR DESCRIPTION
## Summary
- add a dedicated Composer tab
- move composer actions and script parsing into ComposerTab
- hide Composer tab unless composer.json is present
- update main window and tests
- document Composer tab in README

## Testing
- `pytest -q`