### PR TITLE
Add Open Shell button to Docker tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Fusor aims to **simplify routine PHP project operations** via a user-friendly vi
 | **Laravel**  | Migrate, rollback, fresh seed, and other artisan helpers _(visible when framework is Laravel)_ |
 | **Symfony**  | Clear cache and manage Doctrine migrations _(visible when framework is Symfony)_               |
 | **Yii**      | Common Yii console commands _(visible when framework is Yii)_                                  |
-| **Docker**   | Build, pull, restart services, inspect containers _(visible only in Docker mode)_              |
+| **Docker**   | Build, pull, restart services, open shell, inspect containers _(visible only in Docker mode)_              |
 | **Composer** | Run composer install/update and scripts                                                        |
 | **Node**     | Run npm install and package scripts (e.g., dev, build)                                         |
 | **Make**     | Run make targets detected from the project's Makefile _(visible when Makefile present)_        |

--- a/fusor/tabs/docker_tab.py
+++ b/fusor/tabs/docker_tab.py
@@ -29,12 +29,14 @@ class DockerTab(QWidget):
         self.status_btn = self._btn("Status", self.status, icon="dialog-information")
         self.logs_btn = self._btn("Logs", self.logs, icon="text-x-generic")
         self.restart_btn = self._btn("Restart", self.restart, icon="view-refresh")
+        self.shell_btn = self._btn("Open Shell", self.shell, icon="utilities-terminal")
 
         layout.addWidget(self.build_btn)
         layout.addWidget(self.pull_btn)
         layout.addWidget(self.status_btn)
         layout.addWidget(self.logs_btn)
         layout.addWidget(self.restart_btn)
+        layout.addWidget(self.shell_btn)
 
         layout.addStretch(1)
 
@@ -63,3 +65,8 @@ class DockerTab(QWidget):
 
     def restart(self) -> None:
         self.main_window.run_command(["docker", "compose", "restart"])
+
+    def shell(self) -> None:
+        self.main_window.run_command(
+            ["docker", "compose", "exec", self.main_window.php_service, "sh"]
+        )

--- a/tests/test_docker_tab.py
+++ b/tests/test_docker_tab.py
@@ -6,6 +6,7 @@ from fusor.tabs.docker_tab import DockerTab
 class DummyMainWindow:
     def __init__(self):
         self.commands = []
+        self.php_service = "php"
 
     def run_command(self, cmd):
         self.commands.append(cmd)
@@ -21,6 +22,7 @@ def test_buttons_run_commands(monkeypatch, qtbot):
     qtbot.mouseClick(tab.status_btn, Qt.MouseButton.LeftButton)
     qtbot.mouseClick(tab.logs_btn, Qt.MouseButton.LeftButton)
     qtbot.mouseClick(tab.restart_btn, Qt.MouseButton.LeftButton)
+    qtbot.mouseClick(tab.shell_btn, Qt.MouseButton.LeftButton)
 
     assert main.commands == [
         ["docker", "compose", "build"],
@@ -28,4 +30,5 @@ def test_buttons_run_commands(monkeypatch, qtbot):
         ["docker", "compose", "ps"],
         ["docker", "compose", "logs", "--tail", "50"],
         ["docker", "compose", "restart"],
+        ["docker", "compose", "exec", "php", "sh"],
     ]


### PR DESCRIPTION
## Summary
- add shell helper for docker containers
- show an "Open Shell" button on the Docker tab
- test that the button executes the correct command
- document the new button in the README

## Testing
- `pytest -q`