### PR TITLE
Add Composer outdated command button

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Fusor aims to **simplify routine PHP project operations** via a user-friendly vi
 | **Symfony**  | Clear cache and manage Doctrine migrations _(visible when framework is Symfony)_               |
 | **Yii**      | Common Yii console commands _(visible when framework is Yii)_                                  |
 | **Docker**   | Build, pull, restart services, inspect containers _(visible only in Docker mode)_              |
-| **Composer** | Run composer install/update and scripts                                                        |
+| **Composer** | Run composer install/update/outdated and scripts                                                        |
 | **Node**     | Run npm install and package scripts (e.g., dev, build)                                         |
 | **Make**     | Run make targets detected from the project's Makefile _(visible when Makefile present)_        |
 | **Logs**     | View logs with optional auto-refresh and open log files in your default application            |

--- a/fusor/tabs/composer_tab.py
+++ b/fusor/tabs/composer_tab.py
@@ -40,8 +40,12 @@ class ComposerTab(QWidget):
         self.update_btn = self._btn(
             "Composer update", self.composer_update, icon="system-software-update"
         )
+        self.outdated_btn = self._btn(
+            "Composer outdated", self.composer_outdated, icon="view-refresh"
+        )
         layout.addWidget(self.install_btn)
         layout.addWidget(self.update_btn)
+        layout.addWidget(self.outdated_btn)
 
         self.scripts_group = QGroupBox("Composer Scripts")
         self.scripts_layout = QVBoxLayout()
@@ -66,6 +70,9 @@ class ComposerTab(QWidget):
 
     def composer_update(self, _: bool = False) -> None:
         self.main_window.run_command(["composer", "update"])
+
+    def composer_outdated(self, _: bool = False) -> None:
+        self.main_window.run_command(["composer", "outdated"])
 
     def _make_script_handler(self, name: str) -> Callable[[bool], None]:
         """Return a slot that runs the given composer script."""

--- a/tests/test_composer_tab.py
+++ b/tests/test_composer_tab.py
@@ -21,8 +21,13 @@ def test_buttons_run_commands(qtbot):
 
     qtbot.mouseClick(tab.install_btn, Qt.MouseButton.LeftButton)
     qtbot.mouseClick(tab.update_btn, Qt.MouseButton.LeftButton)
+    qtbot.mouseClick(tab.outdated_btn, Qt.MouseButton.LeftButton)
 
-    assert main.commands == [["composer", "install"], ["composer", "update"]]
+    assert main.commands == [
+        ["composer", "install"],
+        ["composer", "update"],
+        ["composer", "outdated"],
+    ]
 
 
 def test_update_composer_scripts_adds_buttons(tmp_path, qtbot):


### PR DESCRIPTION
## Summary
- add a *Composer outdated* button in `ComposerTab`
- call new `composer_outdated` method when clicked
- test that the button executes the expected command
- document the new action in the README

## Testing
- `pytest -q`