### PR TITLE
Use create_button helper everywhere

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -16,7 +16,6 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
     QHBoxLayout,
     QTextEdit,
-    QPushButton,
     QMessageBox,
     QFileDialog,
     QInputDialog,
@@ -37,7 +36,6 @@ if TYPE_CHECKING:
         QCheckBox,
     )
     from PyQt6.QtGui import QCloseEvent
-from .icons import get_icon
 from . import APP_NAME
 
 from .config import (
@@ -357,8 +355,7 @@ class MainWindow(QMainWindow):
         self.output_view.setFixedHeight(200)
         main_layout.addWidget(self.output_view)
 
-        self.clear_output_button = QPushButton("Clear Output")
-        self.clear_output_button.setIcon(get_icon("edit-clear"))
+        self.clear_output_button = create_button("Clear Output", "edit-clear")
         self.clear_output_button.clicked.connect(self.clear_output)
         main_layout.addWidget(self.clear_output_button)
 

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -6,7 +6,6 @@ from PyQt6.QtWidgets import (
     QFormLayout,
     QLineEdit,
     QComboBox,
-    QPushButton,
     QHBoxLayout,
     QFileDialog,
     QInputDialog,
@@ -21,7 +20,6 @@ from PyQt6.QtWidgets import (
 )
 
 from PyQt6.QtCore import Qt
-from ..icons import get_icon
 from ..config import load_config, save_config
 from .. import main_window as mw_module
 from ..ui import create_button, CONTENT_MARGIN
@@ -120,9 +118,7 @@ class SettingsTab(QWidget):
         self.compose_label = QLabel("Compose Files:")
         docker_form.addRow(self.compose_label, self.compose_files_container)
 
-        add_compose_btn = QPushButton("Add Compose File")
-        add_compose_btn.setIcon(get_icon("list-add"))
-        add_compose_btn.setFixedHeight(30)
+        add_compose_btn = create_button("Add Compose File", "list-add")
         add_compose_btn.clicked.connect(lambda: self._add_compose_file_field(""))
         self.add_compose_btn = add_compose_btn
         docker_form.addRow("", self._wrap(add_compose_btn))
@@ -184,9 +180,7 @@ class SettingsTab(QWidget):
         logs_form.setLabelAlignment(Qt.AlignmentFlag.AlignRight)
         logs_form.addRow(self.log_dir_label, self.log_dirs_container)
 
-        add_log_btn = QPushButton("Add Log Directory")
-        add_log_btn.setIcon(get_icon("list-add"))
-        add_log_btn.setFixedHeight(30)
+        add_log_btn = create_button("Add Log Directory", "list-add")
         add_log_btn.clicked.connect(lambda: self._add_log_dir_field(""))
         self.add_log_btn = add_log_btn
         logs_form.addRow("", self._wrap(add_log_btn))

--- a/fusor/welcome_dialog.py
+++ b/fusor/welcome_dialog.py
@@ -7,7 +7,6 @@ from PyQt6.QtWidgets import (
     QDialog,
     QVBoxLayout,
     QLabel,
-    QPushButton,
     QFileDialog,
     QInputDialog,
     QMessageBox,
@@ -17,6 +16,7 @@ from PyQt6.QtCore import Qt
 from typing import Optional
 
 from . import APP_NAME
+from .ui import create_button
 
 
 class WelcomeDialog(QDialog):
@@ -32,15 +32,15 @@ class WelcomeDialog(QDialog):
         layout = QVBoxLayout(self)
         layout.addWidget(QLabel("Select a project to get started:"))
 
-        add_btn = QPushButton("Add Project")
+        add_btn = create_button("Add Project")
         add_btn.clicked.connect(self.add_project)
         layout.addWidget(add_btn)
 
-        create_btn = QPushButton("Create Project")
+        create_btn = create_button("Create Project")
         create_btn.clicked.connect(self.create_project)
         layout.addWidget(create_btn)
 
-        clone_btn = QPushButton("Clone from Git")
+        clone_btn = create_button("Clone from Git")
         clone_btn.clicked.connect(self.clone_project)
         layout.addWidget(clone_btn)
 


### PR DESCRIPTION
## Summary
- update dialogs and tabs to use the shared `create_button` helper
- remove unused imports

## Testing
- `ruff check .`
- `flake8`
- `mypy fusor`
- `pytest -q`