### PR TITLE
Use create_button helper everywhere

### DIFF
--- a/fusor/main_window.py
+++ b/fusor/main_window.py
@@ -16,7 +16,6 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
     QHBoxLayout,
     QTextEdit,
-    QPushButton,
     QMessageBox,
     QFileDialog,
     QInputDialog,
@@ -37,7 +36,6 @@ if TYPE_CHECKING:
         QCheckBox,
     )
     from PyQt6.QtGui import QCloseEvent
-from .icons import get_icon
 from . import APP_NAME
 
 from .config import (
@@ -357,8 +355,7 @@ class MainWindow(QMainWindow):
         self.output_view.setFixedHeight(200)
         main_layout.addWidget(self.output_view)
 
-        self.clear_output_button = QPushButton("Clear Output")
-        self.clear_output_button.setIcon(get_icon("edit-clear"))
+        self.clear_output_button = create_button("Clear Output", "edit-clear")
         self.clear_output_button.clicked.connect(self.clear_output)
         main_layout.addWidget(self.clear_output_button)
 

--- a/fusor/tabs/composer_tab.py
+++ b/fusor/tabs/composer_tab.py
@@ -1,7 +1,6 @@
 from PyQt6.QtWidgets import (
     QWidget,
     QVBoxLayout,
-    QPushButton,
     QScrollArea,
     QGroupBox,
 )
@@ -33,15 +32,14 @@ class ComposerTab(QWidget):
         layout.setContentsMargins(CONTENT_MARGIN, CONTENT_MARGIN, CONTENT_MARGIN, CONTENT_MARGIN)
         layout.setSpacing(DEFAULT_SPACING)
 
-        self.install_btn = self._btn(
-            "Composer install", self.composer_install, icon="package-install"
+        self.install_btn = create_button("Composer install", "package-install")
+        self.install_btn.clicked.connect(self.composer_install)
+        self.update_btn = create_button(
+            "Composer update", "system-software-update"
         )
-        self.update_btn = self._btn(
-            "Composer update", self.composer_update, icon="system-software-update"
-        )
-        self.outdated_btn = self._btn(
-            "Composer outdated", self.composer_outdated, icon="view-refresh"
-        )
+        self.update_btn.clicked.connect(self.composer_update)
+        self.outdated_btn = create_button("Composer outdated", "view-refresh")
+        self.outdated_btn.clicked.connect(self.composer_outdated)
         layout.addWidget(self.install_btn)
         layout.addWidget(self.update_btn)
         layout.addWidget(self.outdated_btn)
@@ -54,11 +52,6 @@ class ComposerTab(QWidget):
         layout.addStretch(1)
 
         self.update_composer_scripts()
-
-    def _btn(self, text: str, slot: Callable[[bool], None], icon: str | None = None) -> QPushButton:
-        btn = create_button(text, icon)
-        btn.clicked.connect(slot)
-        return btn
 
     def composer_install(self, _: bool = False) -> None:
         self.main_window.run_command(["composer", "install"])
@@ -101,11 +94,10 @@ class ComposerTab(QWidget):
         self._script_buttons = []
 
         for name in scripts:
-            btn = self._btn(
-                name.capitalize().replace('-', ' '),
-                self._make_script_handler(name),
-                icon="system-run",
+            btn = create_button(
+                name.capitalize().replace("-", " "), "system-run"
             )
+            btn.clicked.connect(self._make_script_handler(name))
             self.scripts_layout.addWidget(btn)
             self._script_buttons.append(btn)
 

--- a/fusor/tabs/database_tab.py
+++ b/fusor/tabs/database_tab.py
@@ -1,7 +1,6 @@
 from PyQt6.QtWidgets import (
     QWidget,
     QVBoxLayout,
-    QPushButton,
     QGroupBox,
     QFileDialog,
     QScrollArea,
@@ -9,7 +8,6 @@ from PyQt6.QtWidgets import (
     QLabel,
     QHBoxLayout,
 )
-from typing import Callable
 
 from ..ui import create_button, CONTENT_MARGIN
 
@@ -45,21 +43,12 @@ class DatabaseTab(QWidget):
         combo_row.addWidget(self.db_combo)
         tools_layout.addLayout(combo_row)
 
-        self.dbeaver_btn = self._btn(
-            "Open in DBeaver",
-            self.open_dbeaver,
-            icon="database",
-        )
-        self.dump_btn = self._btn(
-            "Dump to SQL",
-            self.dump_sql,
-            icon="document-save",
-        )
-        self.restore_btn = self._btn(
-            "Restore dump",
-            self.restore_dump,
-            icon="document-open",
-        )
+        self.dbeaver_btn = create_button("Open in DBeaver", "database")
+        self.dbeaver_btn.clicked.connect(self.open_dbeaver)
+        self.dump_btn = create_button("Dump to SQL", "document-save")
+        self.dump_btn.clicked.connect(self.dump_sql)
+        self.restore_btn = create_button("Restore dump", "document-open")
+        self.restore_btn.clicked.connect(self.restore_dump)
 
         tools_layout.addWidget(self.dbeaver_btn)
         tools_layout.addWidget(self.dump_btn)
@@ -73,13 +62,6 @@ class DatabaseTab(QWidget):
     def on_framework_changed(self, _text: str) -> None:
         """Database tab has no framework specific controls."""
         pass
-
-    def _btn(
-        self, text: str, slot: Callable[[], None], icon: str | None = None
-    ) -> QPushButton:
-        btn = create_button(text, icon)
-        btn.clicked.connect(slot)
-        return btn
 
     def open_dbeaver(self) -> None:
         self.main_window.run_command(["dbeaver"], service=self.main_window.db_service)

--- a/fusor/tabs/docker_tab.py
+++ b/fusor/tabs/docker_tab.py
@@ -1,6 +1,5 @@
-from PyQt6.QtWidgets import QWidget, QVBoxLayout, QPushButton, QScrollArea
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QScrollArea
 from ..ui import create_button, CONTENT_MARGIN, DEFAULT_SPACING
-from typing import Callable
 
 
 class DockerTab(QWidget):
@@ -24,12 +23,18 @@ class DockerTab(QWidget):
         layout.setContentsMargins(CONTENT_MARGIN, CONTENT_MARGIN, CONTENT_MARGIN, CONTENT_MARGIN)
         layout.setSpacing(DEFAULT_SPACING)
 
-        self.build_btn = self._btn("Rebuild Images", self.build, icon="system-run")
-        self.pull_btn = self._btn("Pull Images", self.pull, icon="go-down")
-        self.status_btn = self._btn("Status", self.status, icon="dialog-information")
-        self.logs_btn = self._btn("Logs", self.logs, icon="text-x-generic")
-        self.restart_btn = self._btn("Restart", self.restart, icon="view-refresh")
-        self.shell_btn = self._btn("Open Shell", self.shell, icon="utilities-terminal")
+        self.build_btn = create_button("Rebuild Images", "system-run")
+        self.build_btn.clicked.connect(self.build)
+        self.pull_btn = create_button("Pull Images", "go-down")
+        self.pull_btn.clicked.connect(self.pull)
+        self.status_btn = create_button("Status", "dialog-information")
+        self.status_btn.clicked.connect(self.status)
+        self.logs_btn = create_button("Logs", "text-x-generic")
+        self.logs_btn.clicked.connect(self.logs)
+        self.restart_btn = create_button("Restart", "view-refresh")
+        self.restart_btn.clicked.connect(self.restart)
+        self.shell_btn = create_button("Open Shell", "utilities-terminal")
+        self.shell_btn.clicked.connect(self.shell)
 
         layout.addWidget(self.build_btn)
         layout.addWidget(self.pull_btn)
@@ -39,13 +44,6 @@ class DockerTab(QWidget):
         layout.addWidget(self.shell_btn)
 
         layout.addStretch(1)
-
-    def _btn(
-        self, text: str, slot: Callable[[], None], icon: str | None = None
-    ) -> QPushButton:
-        btn = create_button(text, icon)
-        btn.clicked.connect(slot)
-        return btn
 
     def build(self) -> None:
         self.main_window.run_command(["docker", "compose", "build"])

--- a/fusor/tabs/git_tab.py
+++ b/fusor/tabs/git_tab.py
@@ -2,7 +2,6 @@ from PyQt6.QtWidgets import (
     QWidget,
     QVBoxLayout,
     QHBoxLayout,
-    QPushButton,
     QMessageBox,
     QGroupBox,
     QLabel,
@@ -15,7 +14,6 @@ from ..branch_dialog import BranchDialog
 from ..ui import create_button, CONTENT_MARGIN
 
 import subprocess
-from typing import Callable
 
 
 class GitTab(QWidget):
@@ -43,11 +41,8 @@ class GitTab(QWidget):
         branch_group = QGroupBox("Active Branch")
         branch_layout = QHBoxLayout()
         self.current_branch_label = QLabel("")
-        checkout_btn = self._btn(
-            "Checkout...",
-            self.show_branch_dialog,
-            icon="document-open",
-        )
+        checkout_btn = create_button("Checkout...", "document-open")
+        checkout_btn.clicked.connect(self.show_branch_dialog)
 
         branch_layout.addWidget(QLabel("Current:"))
         branch_layout.addWidget(self.current_branch_label)
@@ -61,11 +56,8 @@ class GitTab(QWidget):
         create_group = QGroupBox("Create Branch")
         create_layout = QHBoxLayout()
         self.branch_name_edit = QLineEdit()
-        create_btn = self._btn(
-            "Create Branch",
-            self.create_branch,
-            icon="list-add",
-        )
+        create_btn = create_button("Create Branch", "list-add")
+        create_btn.clicked.connect(self.create_branch)
         create_layout.addWidget(self.branch_name_edit)
         create_layout.addWidget(create_btn)
         create_group.setLayout(create_layout)
@@ -76,11 +68,8 @@ class GitTab(QWidget):
         commit_group = QGroupBox("Commit Changes")
         commit_layout = QHBoxLayout()
         self.commit_message_edit = QLineEdit()
-        commit_btn = self._btn(
-            "Commit",
-            self.commit_changes,
-            icon="document-save",
-        )
+        commit_btn = create_button("Commit", "document-save")
+        commit_btn.clicked.connect(self.commit_changes)
         commit_layout.addWidget(self.commit_message_edit)
         commit_layout.addWidget(commit_btn)
         commit_group.setLayout(commit_layout)
@@ -92,41 +81,20 @@ class GitTab(QWidget):
         actions_layout = QVBoxLayout()
         actions_layout.setSpacing(10)
 
-        pull_btn = self._btn(
-            "Pull",
-            lambda: self.run_git_command("pull"),
-            icon="go-down",
-        )
-        push_btn = self._btn(
-            "Push",
-            lambda: self.run_git_command("push"),
-            icon="go-up",
-        )
-        reset_btn = self._btn(
-            "Hard Reset",
-            self.hard_reset,
-            icon="edit-undo",
-        )
-        stash_btn = self._btn(
-            "Stash",
-            self.stash,
-            icon="document-save",
-        )
-        status_btn = self._btn(
-            "Status",
-            self.show_status,
-            icon="dialog-information",
-        )
-        diff_btn = self._btn(
-            "Diff",
-            self.show_diff,
-            icon="document-diff",
-        )
-        view_log_btn = self._btn(
-            "View Log",
-            self.view_log,
-            icon="text-x-generic",
-        )
+        pull_btn = create_button("Pull", "go-down")
+        pull_btn.clicked.connect(lambda: self.run_git_command("pull"))
+        push_btn = create_button("Push", "go-up")
+        push_btn.clicked.connect(lambda: self.run_git_command("push"))
+        reset_btn = create_button("Hard Reset", "edit-undo")
+        reset_btn.clicked.connect(self.hard_reset)
+        stash_btn = create_button("Stash", "document-save")
+        stash_btn.clicked.connect(self.stash)
+        status_btn = create_button("Status", "dialog-information")
+        status_btn.clicked.connect(self.show_status)
+        diff_btn = create_button("Diff", "document-diff")
+        diff_btn.clicked.connect(self.show_diff)
+        view_log_btn = create_button("View Log", "text-x-generic")
+        view_log_btn.clicked.connect(self.view_log)
 
         actions_layout.addWidget(pull_btn)
         actions_layout.addWidget(push_btn)
@@ -140,19 +108,13 @@ class GitTab(QWidget):
         outer_layout.addWidget(actions_group)
         self.actions_group = actions_group
 
-        self.init_btn = self._btn("Init Repository", self.init_repo, icon="list-add")
+        self.init_btn = create_button("Init Repository", "list-add")
+        self.init_btn.clicked.connect(self.init_repo)
         outer_layout.addWidget(self.init_btn)
 
         outer_layout.addStretch(1)
 
         self.update_visibility()
-
-    def _btn(
-        self, label: str, slot: Callable[..., object], icon: str | None = None
-    ) -> QPushButton:
-        btn = create_button(label, icon)
-        btn.clicked.connect(slot)
-        return btn
 
     def run_git_command(self, *args: str) -> subprocess.CompletedProcess[str] | None:
         if not self.main_window.ensure_project_path():

--- a/fusor/tabs/laravel_tab.py
+++ b/fusor/tabs/laravel_tab.py
@@ -1,13 +1,11 @@
 from PyQt6.QtWidgets import (
     QWidget,
     QVBoxLayout,
-    QPushButton,
     QGroupBox,
     QScrollArea,
 )
 
 from ..ui import create_button, CONTENT_MARGIN
-from typing import Callable
 
 
 class LaravelTab(QWidget):
@@ -32,18 +30,18 @@ class LaravelTab(QWidget):
         self.migrate_group = QGroupBox("Laravel Migrations")
         migrate_layout = QVBoxLayout()
         migrate_layout.setSpacing(10)
-        migrate_layout.addWidget(
-            self._btn("Migrate", self.main_window.migrate, icon="system-run")
-        )
-        migrate_layout.addWidget(
-            self._btn("Rollback", self.main_window.rollback, icon="edit-undo")
-        )
-        migrate_layout.addWidget(
-            self._btn("Fresh", self.main_window.fresh, icon="view-refresh")
-        )
-        migrate_layout.addWidget(
-            self._btn("Seed", self.main_window.seed, icon="list-add")
-        )
+        btn = create_button("Migrate", "system-run")
+        btn.clicked.connect(self.main_window.migrate)
+        migrate_layout.addWidget(btn)
+        btn = create_button("Rollback", "edit-undo")
+        btn.clicked.connect(self.main_window.rollback)
+        migrate_layout.addWidget(btn)
+        btn = create_button("Fresh", "view-refresh")
+        btn.clicked.connect(self.main_window.fresh)
+        migrate_layout.addWidget(btn)
+        btn = create_button("Seed", "list-add")
+        btn.clicked.connect(self.main_window.seed)
+        migrate_layout.addWidget(btn)
         self.migrate_group.setLayout(migrate_layout)
         layout.addWidget(self.migrate_group)
 
@@ -51,15 +49,13 @@ class LaravelTab(QWidget):
         self.artisan_group = QGroupBox("Laravel Artisan")
         artisan_layout = QVBoxLayout()
         artisan_layout.setSpacing(10)
-        self.optimize_btn = self._btn(
-            "Optimize",
-            lambda: self.main_window.artisan("optimize"),
-            icon="preferences-system",
+        self.optimize_btn = create_button("Optimize", "preferences-system")
+        self.optimize_btn.clicked.connect(
+            lambda: self.main_window.artisan("optimize")
         )
-        self.config_clear_btn = self._btn(
-            "Config Clear",
-            lambda: self.main_window.artisan("config:clear"),
-            icon="edit-clear",
+        self.config_clear_btn = create_button("Config Clear", "edit-clear")
+        self.config_clear_btn.clicked.connect(
+            lambda: self.main_window.artisan("config:clear")
         )
         artisan_layout.addWidget(self.optimize_btn)
         artisan_layout.addWidget(self.config_clear_btn)
@@ -69,13 +65,6 @@ class LaravelTab(QWidget):
         layout.addStretch(1)
 
         self.on_framework_changed(self.main_window.framework_choice)
-
-    def _btn(
-        self, text: str, slot: Callable[[], None], icon: str | None = None
-    ) -> QPushButton:
-        btn = create_button(text, icon)
-        btn.clicked.connect(slot)
-        return btn
 
     def on_framework_changed(self, text: str) -> None:
         visible = text == "Laravel"

--- a/fusor/tabs/makefile_tab.py
+++ b/fusor/tabs/makefile_tab.py
@@ -1,11 +1,11 @@
 from PyQt6.QtWidgets import (
     QWidget,
     QVBoxLayout,
-    QPushButton,
     QScrollArea,
+    QPushButton,
 )
 from pathlib import Path
-from typing import Callable
+
 import re
 
 from ..ui import create_button, CONTENT_MARGIN, DEFAULT_SPACING
@@ -55,11 +55,6 @@ class MakefileTab(QWidget):
         self.update_commands()
         self._layout.addStretch(1)
 
-    def _btn(self, text: str, slot: Callable[[], None], icon: str | None = None) -> QPushButton:
-        btn = create_button(text, icon)
-        btn.clicked.connect(slot)
-        return btn
-
     def update_commands(self) -> None:
         """Load make targets from the current project."""
         for btn in self._buttons:
@@ -70,10 +65,9 @@ class MakefileTab(QWidget):
         path = Path(self.main_window.project_path) / "Makefile"
         targets = parse_makefile_targets(path)
         for name in targets:
-            btn = self._btn(
-                name.replace("_", " ").capitalize(),
-                partial(self.main_window.run_command, ["make", name]),
-                icon="system-run",
+            btn = create_button(name.replace("_", " ").capitalize(), "system-run")
+            btn.clicked.connect(
+                partial(self.main_window.run_command, ["make", name])
             )
             self._layout.addWidget(btn)
             self._buttons.append(btn)

--- a/fusor/tabs/node_tab.py
+++ b/fusor/tabs/node_tab.py
@@ -1,11 +1,9 @@
 from PyQt6.QtWidgets import (
     QWidget,
     QVBoxLayout,
-    QPushButton,
     QScrollArea,
     QGroupBox,
 )
-from typing import Callable
 from pathlib import Path
 import json
 
@@ -34,9 +32,8 @@ class NodeTab(QWidget):
         layout.setContentsMargins(CONTENT_MARGIN, CONTENT_MARGIN, CONTENT_MARGIN, CONTENT_MARGIN)
         layout.setSpacing(DEFAULT_SPACING)
 
-        self.npm_install_btn = self._btn(
-            "npm install", self.npm_install, icon="system-run"
-        )
+        self.npm_install_btn = create_button("npm install", "system-run")
+        self.npm_install_btn.clicked.connect(self.npm_install)
 
         layout.addWidget(self.npm_install_btn)
 
@@ -48,11 +45,6 @@ class NodeTab(QWidget):
         layout.addStretch(1)
 
         self.update_npm_scripts()
-
-    def _btn(self, text: str, slot: Callable[[], None], icon: str | None = None) -> QPushButton:
-        btn = create_button(text, icon)
-        btn.clicked.connect(slot)
-        return btn
 
     def npm_install(self) -> None:
         self.main_window.run_command(["npm", "install"])
@@ -78,10 +70,11 @@ class NodeTab(QWidget):
         self._script_buttons = []
 
         for name in scripts:
-            btn = self._btn(
-                name.capitalize().replace('-', ' '),
-                partial(self.main_window.run_command, ["npm", "run", name]),
-                icon="system-run",
+            btn = create_button(
+                name.capitalize().replace("-", " "), "system-run"
+            )
+            btn.clicked.connect(
+                partial(self.main_window.run_command, ["npm", "run", name])
             )
             self.npm_scripts_layout.addWidget(btn)
             self._script_buttons.append(btn)

--- a/fusor/tabs/project_tab.py
+++ b/fusor/tabs/project_tab.py
@@ -37,9 +37,10 @@ class ProjectTab(QWidget):
 
         self.start_btn = create_button("Start", "media-playback-start")
         self.start_btn.clicked.connect(main_window.start_project)
-        self.stop_btn = create_button("Stop", "media-playback-stop")
-        self.stop_btn.setStyleSheet(
-            "QPushButton:enabled { background-color: #dc3545; }"
+        self.stop_btn = create_button(
+            "Stop",
+            "media-playback-stop",
+            color="#dc3545",
         )
         self.stop_btn.clicked.connect(main_window.stop_project)
         server_layout.addWidget(self.start_btn)

--- a/fusor/tabs/project_tab.py
+++ b/fusor/tabs/project_tab.py
@@ -7,7 +7,6 @@ from PyQt6.QtWidgets import (
     QWidget,
     QVBoxLayout,
     QHBoxLayout,
-    QPushButton,
     QGroupBox,
     QScrollArea,
 )
@@ -36,62 +35,47 @@ class ProjectTab(QWidget):
         server_group = QGroupBox("Server Control")
         server_layout = QHBoxLayout()
 
-        self.start_btn = self._btn(
-            "Start",
-            main_window.start_project,
-            icon="media-playback-start",
+        self.start_btn = create_button("Start", "media-playback-start")
+        self.start_btn.clicked.connect(main_window.start_project)
+        self.stop_btn = create_button("Stop", "media-playback-stop")
+        self.stop_btn.setStyleSheet(
+            "QPushButton:enabled { background-color: #dc3545; }"
         )
-        self.stop_btn = self._btn(
-            "Stop",
-            main_window.stop_project,
-            icon="media-playback-stop",
-            color="#dc3545",
-        )
+        self.stop_btn.clicked.connect(main_window.stop_project)
         server_layout.addWidget(self.start_btn)
         server_layout.addWidget(self.stop_btn)
 
         server_group.setLayout(server_layout)
         layout.addWidget(server_group)
 
-        self.terminal_btn = self._btn(
-            "Open Terminal",
-            self.open_terminal,
-            icon="utilities-terminal",
-        )
+        self.terminal_btn = create_button("Open Terminal", "utilities-terminal")
+        self.terminal_btn.clicked.connect(self.open_terminal)
         layout.addWidget(self.terminal_btn)
 
-        self.explorer_btn = self._btn(
-            "Open Folder",
-            self.open_explorer,
-            icon="document-open",
-        )
+        self.explorer_btn = create_button("Open Folder", "document-open")
+        self.explorer_btn.clicked.connect(self.open_explorer)
         layout.addWidget(self.explorer_btn)
 
         # --- PHP Tools Group ---
         self.php_tools_group = QGroupBox("PHP Tools")
         php_layout = QVBoxLayout()
 
-        self.phpunit_btn = self._btn(
-            "Run PHPUnit",
-            main_window.phpunit,
-            icon="system-run",
-        )
-        self.rector_btn = self._btn(
-            "Run Rector",
+        self.phpunit_btn = create_button("Run PHPUnit", "system-run")
+        self.phpunit_btn.clicked.connect(main_window.phpunit)
+        self.rector_btn = create_button("Run Rector", "system-run")
+        self.rector_btn.clicked.connect(
             lambda: main_window.run_command(
                 [main_window.php_path, str(Path("vendor") / "bin" / "rector")]
-            ),
-            icon="system-run",
+            )
         )
-        self.csfixer_btn = self._btn(
-            "Run PHP CS-Fixer",
+        self.csfixer_btn = create_button("Run PHP CS-Fixer", "system-run")
+        self.csfixer_btn.clicked.connect(
             lambda: main_window.run_command(
                 [
                     main_window.php_path,
                     str(Path("vendor") / "bin" / "php-cs-fixer"),
                 ]
-            ),
-            icon="system-run",
+            )
         )
 
         php_layout.addWidget(self.phpunit_btn)
@@ -104,15 +88,6 @@ class ProjectTab(QWidget):
         layout.addStretch(1)
 
         self.update_php_tools()
-
-    def _btn(
-        self, label: str, slot, icon: str | None = None, color: str | None = None
-    ) -> QPushButton:
-        btn = create_button(label, icon)
-        if color:
-            btn.setStyleSheet(f"QPushButton:enabled {{ background-color: {color}; }}")
-        btn.clicked.connect(slot)
-        return btn
 
     def open_terminal(self) -> None:
         """Open a new terminal window in the current project directory."""

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -6,7 +6,6 @@ from PyQt6.QtWidgets import (
     QFormLayout,
     QLineEdit,
     QComboBox,
-    QPushButton,
     QHBoxLayout,
     QFileDialog,
     QInputDialog,
@@ -21,7 +20,6 @@ from PyQt6.QtWidgets import (
 )
 
 from PyQt6.QtCore import Qt
-from ..icons import get_icon
 from ..config import load_config, save_config
 from .. import main_window as mw_module
 from ..ui import create_button, CONTENT_MARGIN
@@ -120,9 +118,7 @@ class SettingsTab(QWidget):
         self.compose_label = QLabel("Compose Files:")
         docker_form.addRow(self.compose_label, self.compose_files_container)
 
-        add_compose_btn = QPushButton("Add Compose File")
-        add_compose_btn.setIcon(get_icon("list-add"))
-        add_compose_btn.setFixedHeight(30)
+        add_compose_btn = create_button("Add Compose File", "list-add")
         add_compose_btn.clicked.connect(lambda: self._add_compose_file_field(""))
         self.add_compose_btn = add_compose_btn
         docker_form.addRow("", self._wrap(add_compose_btn))
@@ -184,9 +180,7 @@ class SettingsTab(QWidget):
         logs_form.setLabelAlignment(Qt.AlignmentFlag.AlignRight)
         logs_form.addRow(self.log_dir_label, self.log_dirs_container)
 
-        add_log_btn = QPushButton("Add Log Directory")
-        add_log_btn.setIcon(get_icon("list-add"))
-        add_log_btn.setFixedHeight(30)
+        add_log_btn = create_button("Add Log Directory", "list-add")
         add_log_btn.clicked.connect(lambda: self._add_log_dir_field(""))
         self.add_log_btn = add_log_btn
         logs_form.addRow("", self._wrap(add_log_btn))

--- a/fusor/tabs/symfony_tab.py
+++ b/fusor/tabs/symfony_tab.py
@@ -1,13 +1,11 @@
 from PyQt6.QtWidgets import (
     QWidget,
     QVBoxLayout,
-    QPushButton,
     QGroupBox,
     QScrollArea,
 )
 
 from ..ui import create_button, CONTENT_MARGIN
-from typing import Callable
 
 
 class SymfonyTab(QWidget):
@@ -32,25 +30,21 @@ class SymfonyTab(QWidget):
         console_layout = QVBoxLayout()
         console_layout.setSpacing(10)
 
-        self.cache_clear_btn = self._btn(
-            "Cache Clear",
-            lambda: self.main_window.symfony("cache:clear"),
-            icon="view-refresh",
+        self.cache_clear_btn = create_button("Cache Clear", "view-refresh")
+        self.cache_clear_btn.clicked.connect(
+            lambda: self.main_window.symfony("cache:clear")
         )
-        self.migrate_btn = self._btn(
-            "Migrate",
-            lambda: self.main_window.symfony("doctrine:migrations:migrate"),
-            icon="system-run",
+        self.migrate_btn = create_button("Migrate", "system-run")
+        self.migrate_btn.clicked.connect(
+            lambda: self.main_window.symfony("doctrine:migrations:migrate")
         )
-        self.status_btn = self._btn(
-            "Migration Status",
-            lambda: self.main_window.symfony("doctrine:migrations:status"),
-            icon="dialog-information",
+        self.status_btn = create_button("Migration Status", "dialog-information")
+        self.status_btn.clicked.connect(
+            lambda: self.main_window.symfony("doctrine:migrations:status")
         )
-        self.make_migration_btn = self._btn(
-            "Make Migration",
-            lambda: self.main_window.symfony("make:migration"),
-            icon="document-new",
+        self.make_migration_btn = create_button("Make Migration", "document-new")
+        self.make_migration_btn.clicked.connect(
+            lambda: self.main_window.symfony("make:migration")
         )
 
         console_layout.addWidget(self.cache_clear_btn)
@@ -63,13 +57,6 @@ class SymfonyTab(QWidget):
         layout.addStretch(1)
 
         self.on_framework_changed(self.main_window.framework_choice)
-
-    def _btn(
-        self, text: str, slot: Callable[[], None], icon: str | None = None
-    ) -> QPushButton:
-        btn = create_button(text, icon)
-        btn.clicked.connect(slot)
-        return btn
 
     def on_framework_changed(self, text: str) -> None:
         visible = text == "Symfony"

--- a/fusor/tabs/terminal_tab.py
+++ b/fusor/tabs/terminal_tab.py
@@ -43,10 +43,7 @@ class TerminalTab(QWidget):
         self.start_btn = create_button("Start Shell")
         self.start_btn.clicked.connect(self.start_shell)
         btn_layout.addWidget(self.start_btn)
-        self.stop_btn = create_button("Stop")
-        self.stop_btn.setStyleSheet(
-            "QPushButton:enabled { background-color: #dc3545; }"
-        )
+        self.stop_btn = create_button("Stop", color="#dc3545")
         self.stop_btn.setEnabled(False)
         self.stop_btn.clicked.connect(self.stop_shell)
         btn_layout.addWidget(self.stop_btn)

--- a/fusor/tabs/yii_tab.py
+++ b/fusor/tabs/yii_tab.py
@@ -1,13 +1,11 @@
 from PyQt6.QtWidgets import (
     QWidget,
     QVBoxLayout,
-    QPushButton,
     QGroupBox,
     QScrollArea,
 )
 
 from ..ui import create_button, CONTENT_MARGIN
-from typing import Callable
 
 
 class YiiTab(QWidget):
@@ -32,20 +30,17 @@ class YiiTab(QWidget):
         console_layout = QVBoxLayout()
         console_layout.setSpacing(10)
 
-        self.cache_flush_btn = self._btn(
-            "Cache Flush",
-            lambda: self.main_window.yii("cache/flush-all"),
-            icon="view-refresh",
+        self.cache_flush_btn = create_button("Cache Flush", "view-refresh")
+        self.cache_flush_btn.clicked.connect(
+            lambda: self.main_window.yii("cache/flush-all")
         )
-        self.migrate_btn = self._btn(
-            "Migrate",
-            lambda: self.main_window.yii("migrate"),
-            icon="system-run",
+        self.migrate_btn = create_button("Migrate", "system-run")
+        self.migrate_btn.clicked.connect(
+            lambda: self.main_window.yii("migrate")
         )
-        self.make_migration_btn = self._btn(
-            "Make Migration",
-            lambda: self.main_window.yii("migrate/create"),
-            icon="document-new",
+        self.make_migration_btn = create_button("Make Migration", "document-new")
+        self.make_migration_btn.clicked.connect(
+            lambda: self.main_window.yii("migrate/create")
         )
 
         console_layout.addWidget(self.cache_flush_btn)
@@ -57,13 +52,6 @@ class YiiTab(QWidget):
         layout.addStretch(1)
 
         self.on_framework_changed(self.main_window.framework_choice)
-
-    def _btn(
-        self, text: str, slot: Callable[[], None], icon: str | None = None
-    ) -> QPushButton:
-        btn = create_button(text, icon)
-        btn.clicked.connect(slot)
-        return btn
 
     def on_framework_changed(self, text: str) -> None:
         visible = text == "Yii"

--- a/fusor/ui.py
+++ b/fusor/ui.py
@@ -9,8 +9,26 @@ CONTENT_MARGIN = 20
 DEFAULT_SPACING = 12
 
 
-def create_button(text: str = "", icon: Optional[str] = None, *, fixed: bool = False) -> QPushButton:
-    """Return a QPushButton using the shared style constants."""
+def create_button(
+    text: str = "",
+    icon: Optional[str] = None,
+    *,
+    fixed: bool = False,
+    color: Optional[str] = None,
+) -> QPushButton:
+    """Return a QPushButton using the shared style constants.
+
+    Parameters
+    ----------
+    text:
+        Button label text.
+    icon:
+        Optional icon name from the theme.
+    fixed:
+        If ``True``, create a square button using ``BUTTON_SIZE``.
+    color:
+        Optional background color applied when the button is enabled.
+    """
     btn = QPushButton(text)
     if icon:
         btn.setIcon(get_icon(icon))
@@ -19,4 +37,6 @@ def create_button(text: str = "", icon: Optional[str] = None, *, fixed: bool = F
     else:
         btn.setMinimumHeight(BUTTON_SIZE)
     btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+    if color:
+        btn.setStyleSheet(f"QPushButton:enabled {{ background-color: {color}; }}")
     return btn

--- a/fusor/welcome_dialog.py
+++ b/fusor/welcome_dialog.py
@@ -7,7 +7,6 @@ from PyQt6.QtWidgets import (
     QDialog,
     QVBoxLayout,
     QLabel,
-    QPushButton,
     QFileDialog,
     QInputDialog,
     QMessageBox,
@@ -17,6 +16,7 @@ from PyQt6.QtCore import Qt
 from typing import Optional
 
 from . import APP_NAME
+from .ui import create_button
 
 
 class WelcomeDialog(QDialog):
@@ -32,15 +32,15 @@ class WelcomeDialog(QDialog):
         layout = QVBoxLayout(self)
         layout.addWidget(QLabel("Select a project to get started:"))
 
-        add_btn = QPushButton("Add Project")
+        add_btn = create_button("Add Project")
         add_btn.clicked.connect(self.add_project)
         layout.addWidget(add_btn)
 
-        create_btn = QPushButton("Create Project")
+        create_btn = create_button("Create Project")
         create_btn.clicked.connect(self.create_project)
         layout.addWidget(create_btn)
 
-        clone_btn = QPushButton("Clone from Git")
+        clone_btn = create_button("Clone from Git")
         clone_btn.clicked.connect(self.clone_project)
         layout.addWidget(clone_btn)
 


### PR DESCRIPTION
## Summary
- update dialogs and tabs to use the shared `create_button` helper
- remove unused imports

## Testing
- `ruff check .`
- `flake8`
- `mypy fusor`
- `pytest -q`