### PR TITLE
Add speech output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Fusor aims to **simplify routine PHP project operations** via a user-friendly vi
 -   Basic Node/NPM commands with automatic buttons for package scripts
 -   Detects **Makefiles** and provides buttons for each target
 -   Configurable log viewer with auto-refresh
+-   Optional text-to-speech via **Speak Output** button
 -   **Ctrl+S** shortcut to quickly save settings
 -   Isolated settings stored in `~/.fusor_config.json`
 

--- a/fusor/config.py
+++ b/fusor/config.py
@@ -40,6 +40,7 @@ DEFAULT_CONFIG = {
     "theme": "dark",
     "show_console_output": False,
     "enable_tray": True,
+    "speak_output": False,
     # Window geometry (width, height) and position (x, y)
     "window_size": [1024, 768],
     "window_position": [100, 100],

--- a/fusor/tabs/settings_tab.py
+++ b/fusor/tabs/settings_tab.py
@@ -219,6 +219,11 @@ class SettingsTab(QWidget):
             )
         misc_form.addRow("", self.console_output_checkbox)
 
+        self.speak_checkbox = QCheckBox("Enable Speech")
+        if hasattr(self.main_window, "speak_output"):
+            self.speak_checkbox.setChecked(self.main_window.speak_output)
+        misc_form.addRow("", self.speak_checkbox)
+
         self.tray_checkbox = QCheckBox("Enable System Tray Icon")
         if hasattr(self.main_window, "tray_enabled"):
             self.tray_checkbox.setChecked(self.main_window.tray_enabled)
@@ -238,6 +243,7 @@ class SettingsTab(QWidget):
         self.docker_checkbox.toggled.connect(self.on_docker_toggled)
         self.terminal_checkbox.toggled.connect(self.on_terminal_toggled)
         self.console_output_checkbox.toggled.connect(self.on_console_output_toggled)
+        self.speak_checkbox.toggled.connect(self.on_speak_toggled)
         self.tray_checkbox.toggled.connect(self.on_tray_toggled)
         docker_form.addRow("", self.docker_checkbox)
 
@@ -278,10 +284,12 @@ class SettingsTab(QWidget):
         self.main_window.open_browser_checkbox = self.open_browser_checkbox
         self.main_window.console_output_checkbox = self.console_output_checkbox
         self.main_window.tray_checkbox = self.tray_checkbox
+        self.main_window.speak_checkbox = self.speak_checkbox
 
         self.on_docker_toggled(self.docker_checkbox.isChecked())
         self.on_terminal_toggled(self.terminal_checkbox.isChecked())
         self.on_console_output_toggled(self.console_output_checkbox.isChecked())
+        self.on_speak_toggled(self.speak_checkbox.isChecked())
         self.on_tray_toggled(self.tray_checkbox.isChecked())
         current_fw = self.framework_combo.currentText()
         self.on_framework_changed(current_fw)
@@ -320,6 +328,9 @@ class SettingsTab(QWidget):
             self.main_window.mark_settings_dirty
         )
         self.console_output_checkbox.toggled.connect(
+            self.main_window.mark_settings_dirty
+        )
+        self.speak_checkbox.toggled.connect(
             self.main_window.mark_settings_dirty
         )
         self.tray_checkbox.toggled.connect(
@@ -475,6 +486,11 @@ class SettingsTab(QWidget):
         if hasattr(self.main_window, "output_view"):
             self.main_window.show_console_output = checked
             self.main_window._update_responsive_layout()
+
+    def on_speak_toggled(self, checked: bool) -> None:
+        if hasattr(self.main_window, "speak_button"):
+            self.main_window.speak_output = checked
+            self.main_window.speak_button.setEnabled(checked)
 
     def on_tray_toggled(self, checked: bool) -> None:
         self.main_window.tray_enabled = checked

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ authors = [{name = "Fusor Dev"}]
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "PyQt6~=6.9"
+    "PyQt6~=6.9",
+    "pyttsx3"
 ]
 
 [project.scripts]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest-cov>=5
 ruff
 mypy>=1.10
 flake8
+pyttsx3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PyQt6~=6.9
+pyttsx3

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,6 +32,7 @@ def test_save_then_load(tmp_path, monkeypatch):
     loaded = config.load_config()
     data.setdefault("show_console_output", False)
     data.setdefault("enable_tray", True)
+    data.setdefault("speak_output", False)
     assert loaded == data
 
 def test_load_missing_file(tmp_path, monkeypatch):

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -1281,18 +1281,21 @@ class TestMainWindow:
 
         assert not win.output_view.isVisible()
         assert not win.clear_output_button.isVisible()
+        assert not win.speak_button.isVisible()
 
         win.resize(900, 700)
         qtbot.wait(10)
 
         assert not win.output_view.isVisible()
         assert not win.clear_output_button.isVisible()
+        assert not win.speak_button.isVisible()
 
         win.show_console_output = True
         win._update_responsive_layout()
 
         assert win.output_view.isVisible()
         assert win.clear_output_button.isVisible()
+        assert win.speak_button.isVisible()
 
     def test_minimum_window_size(self, qtbot, monkeypatch):
         monkeypatch.setattr(QTimer, "singleShot", lambda *a, **k: None, raising=True)
@@ -1304,6 +1307,20 @@ class TestMainWindow:
 
         assert win.minimumWidth() == 425
         assert win.minimumHeight() == 300
+
+    def test_speak_button_enabled_by_checkbox(self, qtbot, monkeypatch):
+        monkeypatch.setattr(QTimer, "singleShot", lambda *a, **k: None, raising=True)
+        monkeypatch.setattr(mw_module, "load_config", lambda: {}, raising=True)
+        monkeypatch.setattr(mw_module, "save_config", lambda *a, **k: None, raising=True)
+
+        win = MainWindow()
+        qtbot.addWidget(win)
+        win.show()
+
+        assert not win.speak_button.isEnabled()
+        win.speak_checkbox.setChecked(True)
+        qtbot.wait(10)
+        assert win.speak_button.isEnabled()
 
     def test_add_project_populates_remote_combo(self, tmp_path: Path, qtbot, monkeypatch):
         remotes: list[str] = []


### PR DESCRIPTION
## Summary
- allow speaking console output via pyttsx3
- add Speak Output toggle in Settings
- document new feature
- update tests

## Testing
- `ruff check .`
- `flake8 fusor`
- `mypy fusor`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c69da588c83229d83535ff1d863e2